### PR TITLE
Add myself as steward for the CoC

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -69,8 +69,8 @@ dispute. If you are unable to resolve the matter for any reason, or if the
 behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
-Reports should be directed to *[PROJECT STEWARD NAME(s) AND EMAIL(s)]*, the
-Project Steward(s) for *[PROJECT NAME]*. It is the Project Steward’s duty to
+Reports should be directed to Carlos O'Ryan (coryan@google.com), the
+Project Steward(s) for the Storage Testbench. It is the Project Steward’s duty to
 receive and address reported violations of the code of conduct. They will then
 work with a committee consisting of representatives from the Open Source
 Programs Office and the Google Open Source Strategy team. If for any reason you


### PR DESCRIPTION
The Contributor Covenant requires a named person for conflict resolution.
Adding myself for now, for redundancy we should have additional volunteers.
