### PR TITLE
feat: helpers for uploads and rewrites

### DIFF
--- a/gcs/__init__.py
+++ b/gcs/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gcs import bucket, holder, project

--- a/gcs/bucket.py
+++ b/gcs/bucket.py
@@ -1,0 +1,213 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implement a class to simulate GCS buckets."""
+
+import datetime
+import hashlib
+import json
+import re
+import scalpl
+
+from google.cloud.storage_v1.proto import storage_resources_pb2 as resources_pb2
+from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
+from google.iam.v1 import policy_pb2
+from google.protobuf import json_format
+
+import testbench
+
+
+class Bucket:
+    rest_only_fields = ["iamConfiguration.publicAccessPrevention"]
+
+    def __init__(self, metadata, notifications, iam_policy, rest_only):
+        self.metadata = metadata
+        self.notifications = notifications
+        self.iam_policy = iam_policy
+        self.rest_only = rest_only
+
+    @classmethod
+    def __validate_bucket_name(cls, bucket_name, context):
+        valid = True
+        if "." in bucket_name:
+            valid &= len(bucket_name) <= 222
+            valid &= all([len(part) <= 63 for part in bucket_name.split(".")])
+        else:
+            valid &= len(bucket_name) <= 63
+            valid &= (
+                re.match("^[a-z0-9][a-z0-9._\\-]+[a-z0-9]$", bucket_name) is not None
+            )
+            valid &= not bucket_name.startswith("goog")
+            valid &= re.search("g[0o][0o]g[1l][e3]", bucket_name) is None
+        if not valid:
+            testbench.error.invalid("Bucket name %s" % bucket_name, context)
+
+    @classmethod
+    def __preprocess_rest(cls, data):
+        proxy = scalpl.Cut(data)
+        keys = testbench.common.nested_key(data)
+        proxy.pop("iamConfiguration.bucketPolicyOnly", False)
+        for key in keys:
+            if key.endswith("createdBefore"):
+                proxy[key] = proxy[key] + "T00:00:00Z"
+        rest_only = {}
+        for field in Bucket.rest_only_fields:
+            if field in proxy:
+                rest_only[field] = proxy.pop(field)
+        return proxy.data, rest_only
+
+    @classmethod
+    def __insert_predefined_acl(cls, metadata, predefined_acl, context):
+        if (
+            predefined_acl == ""
+            or predefined_acl
+            == CommonEnums.PredefinedBucketAcl.PREDEFINED_BUCKET_ACL_UNSPECIFIED
+        ):
+            return
+        if metadata.iam_configuration.uniform_bucket_level_access.enabled:
+            testbench.error.invalid(
+                "Predefined ACL with uniform bucket level access enabled", context
+            )
+        acls = testbench.acl.compute_predefined_bucket_acl(
+            metadata.name, predefined_acl, context
+        )
+        del metadata.acl[:]
+        metadata.acl.extend(acls)
+
+    @classmethod
+    def __insert_predefined_default_object_acl(
+        cls, metadata, predefined_default_object_acl, context
+    ):
+        if (
+            predefined_default_object_acl == ""
+            or predefined_default_object_acl
+            == CommonEnums.PredefinedObjectAcl.PREDEFINED_OBJECT_ACL_UNSPECIFIED
+        ):
+            return
+        if metadata.iam_configuration.uniform_bucket_level_access.enabled:
+            testbench.error.invalid(
+                "Predefined Default Object ACL with uniform bucket level access enabled",
+                context,
+            )
+        acls = testbench.acl.compute_predefined_default_object_acl(
+            metadata.name, predefined_default_object_acl, context
+        )
+        del metadata.default_object_acl[:]
+        metadata.default_object_acl.extend(acls)
+
+    @classmethod
+    def __enrich_acl(cls, metadata):
+        for entry in metadata.acl:
+            entry.bucket = metadata.name
+        for entry in metadata.default_object_acl:
+            entry.bucket = metadata.name
+
+    # === INITIALIZATION === #
+
+    @classmethod
+    def init(cls, request, context, rest_only=None):
+        time_created = datetime.datetime.now()
+        metadata = None
+        if context is not None:
+            metadata = request.bucket
+        else:
+            metadata, rest_only = cls.__preprocess_rest(json.loads(request.data))
+            metadata = json_format.ParseDict(metadata, resources_pb2.Bucket())
+        cls.__validate_bucket_name(metadata.name, context)
+        default_projection = CommonEnums.Projection.NO_ACL
+        if len(metadata.acl) != 0 or len(metadata.default_object_acl) != 0:
+            default_projection = CommonEnums.Projection.FULL
+        is_uniform = metadata.iam_configuration.uniform_bucket_level_access.enabled
+        metadata.iam_configuration.uniform_bucket_level_access.enabled = False
+        if len(metadata.acl) == 0:
+            predefined_acl = testbench.acl.extract_predefined_acl(
+                request, False, context
+            )
+            if (
+                predefined_acl
+                == CommonEnums.PredefinedBucketAcl.PREDEFINED_BUCKET_ACL_UNSPECIFIED
+            ):
+                predefined_acl = (
+                    CommonEnums.PredefinedBucketAcl.BUCKET_ACL_PROJECT_PRIVATE
+                )
+            elif predefined_acl == "":
+                predefined_acl = "projectPrivate"
+            elif is_uniform:
+                testbench.error.invalid(
+                    "Predefined ACL with uniform bucket level access enabled", context
+                )
+            cls.__insert_predefined_acl(metadata, predefined_acl, context)
+        if len(metadata.default_object_acl) == 0:
+            predefined_default_object_acl = (
+                testbench.acl.extract_predefined_default_object_acl(request, context)
+            )
+            if (
+                predefined_default_object_acl
+                == CommonEnums.PredefinedObjectAcl.PREDEFINED_OBJECT_ACL_UNSPECIFIED
+            ):
+                predefined_default_object_acl = (
+                    CommonEnums.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE
+                )
+            elif predefined_default_object_acl == "":
+                predefined_default_object_acl = "projectPrivate"
+            elif is_uniform:
+                testbench.error.invalid(
+                    "Predefined Default Object ACL with uniform bucket level access enabled",
+                    context,
+                )
+            cls.__insert_predefined_default_object_acl(
+                metadata, predefined_default_object_acl, context
+            )
+        cls.__enrich_acl(metadata)
+        metadata.iam_configuration.uniform_bucket_level_access.enabled = is_uniform
+        metadata.id = metadata.name
+        metadata.project_number = int(testbench.acl.PROJECT_NUMBER)
+        metadata.metageneration = 0
+        metadata.etag = hashlib.md5(metadata.name.encode("utf-8")).hexdigest()
+        metadata.time_created.FromDatetime(time_created)
+        metadata.updated.FromDatetime(time_created)
+        metadata.owner.entity = testbench.acl.get_project_entity("owners", context)
+        metadata.owner.entity_id = hashlib.md5(
+            metadata.owner.entity.encode("utf-8")
+        ).hexdigest()
+        if rest_only is None:
+            rest_only = {}
+        return (
+            cls(metadata, {}, cls.__init_iam_policy(metadata, context), rest_only),
+            testbench.common.extract_projection(request, default_projection, context),
+        )
+
+    # === IAM === #
+
+    @classmethod
+    def __init_iam_policy(cls, metadata, context):
+        role_mapping = {
+            "READER": "roles/storage.legacyBucketReader",
+            "WRITER": "roles/storage.legacyBucketWriter",
+            "OWNER": "roles/storage.legacyBucketOwner",
+        }
+        bindings = []
+        for entry in metadata.acl:
+            legacy_role = entry.role
+            if legacy_role is None or entry.entity is None:
+                testbench.error.invalid("ACL entry", context)
+            role = role_mapping.get(legacy_role)
+            if role is None:
+                testbench.error.invalid("Legacy role %s" % legacy_role, context)
+            bindings.append(policy_pb2.Binding(role=role, members=[entry.entity]))
+        return policy_pb2.Policy(
+            version=1,
+            bindings=bindings,
+            etag=datetime.datetime.now().isoformat().encode("utf-8"),
+        )

--- a/gcs/holder.py
+++ b/gcs/holder.py
@@ -1,0 +1,202 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implement a holder for resumable upload's data and rewrite's data"""
+
+import flask
+import hashlib
+import json
+import types
+
+from google.cloud.storage_v1.proto import storage_resources_pb2 as resources_pb2
+from google.protobuf import json_format
+
+import testbench
+
+
+class DataHolder(types.SimpleNamespace):
+    rest_only_fields = ["customTime"]
+    __upload_id_generator = 0
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    # === UPLOAD === #
+
+    @classmethod
+    def __extract_rest_only(cls, data):
+        rest_only = {}
+        for field in DataHolder.rest_only_fields:
+            if field in data:
+                rest_only[field] = data.pop(field)
+        return rest_only
+
+    @classmethod
+    def init_upload(
+        cls, request, metadata, bucket, location, upload_id, rest_only=None
+    ):
+        return cls(
+            request=request,
+            metadata=metadata,
+            bucket=bucket,
+            location=location,
+            upload_id=upload_id,
+            media=b"",
+            complete=False,
+            transfer=set(),
+            rest_only=rest_only,
+        )
+
+    @classmethod
+    def __preprocess_rest_metadata(cls, metadata):
+        return testbench.common.rest_adjust(
+            metadata,
+            {
+                "crc32c": lambda x: (
+                    "crc32c",
+                    testbench.common.rest_crc32c_to_proto(metadata["crc32c"]),
+                )
+            },
+        )
+
+    @classmethod
+    def __create_upload_id(cls, bucket_name, object_name):
+        cls.__upload_id_generator = cls.__upload_id_generator + 1
+        return hashlib.sha256(
+            (
+                "%d/%s/o/%s" % (cls.__upload_id_generator, bucket_name, object_name)
+            ).encode("utf-8")
+        ).hexdigest()
+
+    @classmethod
+    def init_resumable_rest(cls, request, bucket):
+        query_name = request.args.get("name", None)
+        rest_only = {}
+        metadata = resources_pb2.Object()
+        if len(request.data) > 0:
+            data = json.loads(request.data)
+            data_name = data.get("name", None)
+            if (
+                query_name is not None
+                and data_name is not None
+                and query_name != data_name
+            ):
+                testbench.error.invalid(
+                    "Value '%s' in content does not agree with value '%s'."
+                    % (data_name, query_name),
+                    context=None,
+                )
+            rest_only = cls.__extract_rest_only(data)
+            metadata = json_format.ParseDict(
+                cls.__preprocess_rest_metadata(data), metadata
+            )
+            # Add some annotations to make it easier to write tests
+            metadata.metadata["x_emulator_upload"] = "resumable"
+            if data.get("crc32c", None) is not None:
+                metadata.metadata["x_emulator_crc32c"] = data.get("crc32c")
+            if data.get("md5Hash", None) is not None:
+                metadata.metadata["x_emulator_md5"] = data.get("md5Hash")
+        if metadata.metadata.get("x_emulator_crc32c", None) is None:
+            metadata.metadata["x_emulator_no_crc32c"] = "true"
+        if metadata.metadata.get("x_emulator_md5", None) is None:
+            metadata.metadata["x_emulator_no_md5"] = "true"
+        if query_name:
+            metadata.name = query_name
+        if metadata.name == "":
+            testbench.error.invalid("No object name", context=None)
+        if metadata.content_type == "":
+            metadata.content_type = request.headers.get(
+                "x-upload-content-type", "application/octet-stream"
+            )
+        upload_id = cls.__create_upload_id(bucket.name, metadata.name)
+        location = (
+            request.host_url
+            + "upload/storage/v1/b/%s/o?uploadType=resumable&upload_id=%s"
+            % (bucket.name, upload_id)
+        )
+        headers = {
+            key.lower(): value
+            for key, value in request.headers.items()
+            if key.lower().startswith("x-")
+        }
+        request = testbench.common.FakeRequest(
+            args=request.args.to_dict(), headers=headers, data=b""
+        )
+        return cls.init_upload(
+            request, metadata, bucket, location, upload_id, rest_only
+        )
+
+    @classmethod
+    def init_resumable_grpc(cls, request, bucket, context):
+        metadata = request.insert_object_spec.resource
+        # Add some annotations to make it easier to write tests
+        metadata.metadata["x_emulator_upload"] = "resumable"
+        if metadata.HasField("crc32c"):
+            metadata.metadata[
+                "x_emulator_crc32c"
+            ] = testbench.common.rest_crc32c_from_proto(metadata.crc32c.value)
+        else:
+            metadata.metadata["x_emulator_no_crc32c"] = "true"
+        if metadata.md5_hash is not None and metadata.md5_hash != "":
+            metadata.metadata["x_emulator_md5"] = metadata.md5_hash
+        else:
+            metadata.metadata["x_emulator_no_md5"] = "true"
+        upload_id = cls.__create_upload_id(bucket.name, metadata.name)
+        fake_request = testbench.common.FakeRequest.init_protobuf(request, context)
+        fake_request.update_protobuf(request.insert_object_spec, context)
+        return cls.init_upload(fake_request, metadata, bucket, "", upload_id)
+
+    def resumable_status_rest(self):
+        response = flask.make_response()
+        if len(self.media) > 1 and not self.complete:
+            response.headers["Range"] = "bytes=0-%d" % (len(self.media) - 1)
+        response.status_code = 308
+        return response
+
+    # === REWRITE === #
+
+    # TODO(#22) - this should be in a separate class
+    @classmethod
+    def init_rewrite_rest(
+        cls, request, src_bucket_name, src_object_name, dst_bucket_name, dst_object_name
+    ):
+        fake_request = testbench.common.FakeRequest(
+            args=request.args.to_dict(),
+            headers={
+                key.lower(): value
+                for key, value in request.headers.items()
+                if key.lower().startswith("x-")
+            },
+            data=request.data,
+        )
+        max_bytes_rewritten_per_call = min(
+            int(fake_request.args.get("maxBytesRewrittenPerCall", 1024 * 1024)),
+            1024 * 1024,
+        )
+        token = hashlib.sha256(
+            (
+                "%s/o/%s/rewriteTo/b/%s/o/%s"
+                % (src_bucket_name, src_object_name, dst_bucket_name, dst_object_name)
+            ).encode("utf-8")
+        ).hexdigest()
+        return cls(
+            request=fake_request,
+            src_bucket_name=src_bucket_name,
+            src_object_name=src_object_name,
+            dst_bucket_name=dst_bucket_name,
+            dst_object_name=dst_object_name,
+            token=token,
+            media=b"",
+            max_bytes_rewritten_per_call=max_bytes_rewritten_per_call,
+        )

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Bucket class (see gcs/bucket.py)."""
+
+import json
+import unittest
+
+from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
+from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
+from google.protobuf import json_format
+
+import gcs
+import testbench
+
+
+class TestBucket(unittest.TestCase):
+    def test_init_simple(self):
+        request = testbench.common.FakeRequest(
+            args={},
+            data=json.dumps({"name": "bucket"}),
+        )
+        bucket, projection = gcs.bucket.Bucket.init(request, None)
+        self.assertEqual(bucket.metadata.name, "bucket")
+
+    def test_init_validates_names(self):
+        request = testbench.common.FakeRequest(
+            args={},
+            data=json.dumps({"name": "short.names.for.domain.buckets.example.com"}),
+        )
+        bucket, _ = gcs.bucket.Bucket.init(request, None)
+        self.assertEqual(
+            bucket.metadata.name, "short.names.for.domain.buckets.example.com"
+        )
+        invalid_names = [
+            "goog-is-not-a-valid-prefix",
+            "hiding-google-is-not-valid",
+            "hiding-g00gl3-is-not-valid",
+            "name-too-long-" + ("a" * 63),
+            (".a" * 64) + ".part-too-long.com",
+            ("a" * 222) + ".domain-name-too-long.com",
+        ]
+        for name in invalid_names:
+            request = testbench.common.FakeRequest(
+                args={},
+                data=json.dumps({"name": "goog-is-not-a-valid-prefix"}),
+            )
+            with self.assertRaises(testbench.error.RestException) as rest:
+                bucket, _ = gcs.bucket.Bucket.init(request, None)
+            self.assertEqual(rest.exception.code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_holder.py
+++ b/tests/test_holder.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Object class (see gcs/object.py)."""
+
+import flask
+import json
+import unittest
+
+from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
+from google.cloud.storage_v1.proto import storage_resources_pb2 as resources_pb2
+from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
+from google.protobuf import json_format
+
+from werkzeug.test import create_environ
+from werkzeug.wrappers import Request
+
+import gcs
+import testbench
+
+
+class TestHolder(unittest.TestCase):
+    def test_init_resumable_rest_incorrect_usage(self):
+        bucket_metadata = json.dumps({"name": "bucket-test"})
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            content_length=len(bucket_metadata),
+            data=bucket_metadata,
+            content_type="application/json",
+            method="POST",
+        )
+
+        bucket, _ = gcs.bucket.Bucket.init(Request(environ), None)
+        bucket = bucket.metadata
+        with self.assertRaises(testbench.error.RestException) as cm:
+            data = "{}"
+            environ = create_environ(
+                base_url="http://localhost:8080",
+                content_length=len(data),
+                data=data,
+                content_type="application/json",
+                method="POST",
+            )
+            upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        self.assertIn("No object name is invalid.", cm.exception.msg)
+
+        with self.assertRaises(testbench.error.RestException) as cm:
+            data = ""
+            environ = create_environ(
+                base_url="http://localhost:8080",
+                content_length=len(data),
+                data=data,
+                content_type="application/json",
+                method="POST",
+            )
+            upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        self.assertIn("No object name is invalid.", cm.exception.msg)
+
+        with self.assertRaises(testbench.error.RestException) as cm:
+            data = json.dumps({"name": ""})
+            environ = create_environ(
+                base_url="http://localhost:8080",
+                query_string={"name": ""},
+                content_length=len(data),
+                data=data,
+                content_type="application/json",
+                method="POST",
+            )
+            _ = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        self.assertIn("No object name is invalid.", cm.exception.msg)
+
+        with self.assertRaises(testbench.error.RestException) as cm:
+            data = json.dumps({"name": "a"})
+            environ = create_environ(
+                base_url="http://localhost:8080",
+                query_string={"name": "b"},
+                content_length=len(data),
+                data=data,
+                content_type="application/json",
+                method="POST",
+            )
+            _ = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        self.assertIn(
+            "Value 'a' in content does not agree with value 'b'. is invalid.",
+            cm.exception.msg,
+        )
+
+        with self.assertRaises(testbench.error.RestException) as cm:
+            data = json.dumps({"name": ""})
+            environ = create_environ(
+                base_url="http://localhost:8080",
+                query_string={"name": "b"},
+                content_length=len(data),
+                data=data,
+                content_type="application/json",
+                method="POST",
+            )
+            _ = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        self.assertIn(
+            "Value '' in content does not agree with value 'b'. is invalid.",
+            cm.exception.msg,
+        )
+
+        with self.assertRaises(testbench.error.RestException) as cm:
+            data = json.dumps({"name": "a"})
+            environ = create_environ(
+                base_url="http://localhost:8080",
+                query_string={"name": ""},
+                content_length=len(data),
+                data=data,
+                content_type="application/json",
+                method="POST",
+            )
+            upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        self.assertIn(
+            "Value 'a' in content does not agree with value ''. is invalid.",
+            cm.exception.msg,
+        )
+
+    def test_init_resumable_rest_correct_usage(self):
+        bucket_metadata = json.dumps({"name": "bucket-test"})
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            content_length=len(bucket_metadata),
+            data=bucket_metadata,
+            content_type="application/json",
+            method="POST",
+        )
+
+        bucket, _ = gcs.bucket.Bucket.init(Request(environ), None)
+        bucket = bucket.metadata
+        data = json.dumps({"name": "a"})
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            query_string={"name": "a"},
+            content_length=len(data),
+            data=data,
+            content_type="application/json",
+            method="POST",
+        )
+        upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+
+        data = json.dumps({"name": "a"})
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            content_length=len(data),
+            data=data,
+            content_type="application/json",
+            method="POST",
+        )
+        upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            query_string={"name": "a"},
+            content_type="application/json",
+            method="POST",
+        )
+        upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+
+        data = json.dumps({"name": None})
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            query_string={"name": "b"},
+            content_length=len(data),
+            data=data,
+            content_type="application/json",
+            method="POST",
+        )
+        upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+
+    def test_init_resumable_grpc(self):
+        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
+        bucket, _ = gcs.bucket.Bucket.init(request, "")
+        bucket = bucket.metadata
+        insert_object_spec = storage_pb2.InsertObjectSpec(
+            resource={"name": "object", "bucket": "bucket"},
+            predefined_acl=CommonEnums.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE,
+            if_generation_not_match={"value": 1},
+            if_metageneration_match={"value": 2},
+            if_metageneration_not_match={"value": 3},
+            projection=CommonEnums.Projection.FULL,
+        )
+        request = storage_pb2.InsertObjectRequest(
+            insert_object_spec=insert_object_spec, write_offset=0
+        )
+        upload = gcs.holder.DataHolder.init_resumable_grpc(request, bucket, "")
+        # Verify the annotations inserted by the emulator.
+        annotations = upload.metadata.metadata
+        self.assertGreaterEqual(
+            set(["x_emulator_upload", "x_emulator_no_crc32c", "x_emulator_no_md5"]),
+            set(annotations.keys()),
+        )
+        # Clear any annotations created by the emulator
+        upload.metadata.metadata.clear()
+        self.assertEqual(
+            upload.metadata, resources_pb2.Object(name="object", bucket="bucket")
+        )
+        predefined_acl = testbench.acl.extract_predefined_acl(upload.request, False, "")
+        self.assertEqual(
+            predefined_acl, CommonEnums.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE
+        )
+        match, not_match = testbench.generation.extract_precondition(
+            upload.request, False, False, ""
+        )
+        self.assertIsNone(match)
+        self.assertEqual(not_match, 1)
+        match, not_match = testbench.generation.extract_precondition(
+            upload.request, True, False, ""
+        )
+        self.assertEqual(match, 2)
+        self.assertEqual(not_match, 3)
+        projection = testbench.common.extract_projection(upload.request, False, "")
+        self.assertEqual(projection, CommonEnums.Projection.FULL)
+
+    def test_resumable_rest(self):
+        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
+        bucket, _ = gcs.bucket.Bucket.init(request, "")
+        bucket = bucket.metadata
+        data = json.dumps(
+            {
+                # Empty payload checksums
+                "crc32c": "AAAAAA==",
+                "md5Hash": "1B2M2Y8AsgTpgAmY7PhCfg==",
+                "name": "test-object-name",
+            }
+        )
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            content_length=len(data),
+            data=data,
+            content_type="application/json",
+            method="POST",
+        )
+        upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        self.assertEqual(upload.metadata.name, "test-object-name")
+        self.assertEqual(upload.metadata.crc32c.value, 0)
+        self.assertEqual(upload.metadata.md5_hash, "1B2M2Y8AsgTpgAmY7PhCfg==")
+
+        app = flask.Flask(__name__)
+        with app.test_request_context():
+            status = upload.resumable_status_rest()
+            self.assertEqual(status.status_code, 308)
+            # Simulate a previous chunk upload
+            upload.media = "The quick brown fox jumps over the lazy dog"
+            status = upload.resumable_status_rest()
+            self.assertEqual(status.status_code, 308)
+            self.assertIn("Range", status.headers)
+            self.assertEqual("bytes=0-42", status.headers.get("Range", None))
+
+    def test_rewrite_rest(self):
+        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
+        bucket, _ = gcs.bucket.Bucket.init(request, "")
+        bucket = bucket.metadata
+        data = json.dumps({"name": "a"})
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            query_string={"maxBytesRewrittenPerCall": 512 * 1024},
+        )
+        upload = gcs.holder.DataHolder.init_rewrite_rest(
+            Request(environ),
+            "source-bucket",
+            "source-object",
+            "destination-bucket",
+            "destination-object",
+        )
+        self.assertEqual(512 * 1024, upload.max_bytes_rewritten_per_call)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add helpers for uploads and rewrites, they are not quite a "resource",
but are long-lived entities in the testbench. Also added some bits of
the Bucket resource because I needed them for the tests.

Part of the work for #24