### PR TITLE
feat: add initial resource database

### DIFF
--- a/testbench/__init__.py
+++ b/testbench/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testbench import acl, common, csek, error, generation, handle_gzip
+from testbench import error, acl, common, csek, database, generation, handle_gzip

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -1,0 +1,246 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import json
+import os
+import uuid
+import re
+
+import gcs
+import testbench
+
+from schema import Schema, SchemaError, And, Use
+from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
+
+
+class Database:
+    def __init__(
+        self,
+        buckets,
+        objects,
+        live_generations,
+        uploads,
+        rewrites,
+        retry_tests,
+        supported_methods,
+    ):
+        self.buckets = buckets
+        self.objects = objects
+        self.live_generations = live_generations
+        self.uploads = uploads
+        self.rewrites = rewrites
+        self.retry_tests = retry_tests
+        self.supported_methods = supported_methods
+
+    @classmethod
+    def init(cls):
+        return cls({}, {}, {}, {}, {}, {}, [])
+
+    def raii(self, grpc_server):
+        self.grpc_server = grpc_server
+
+    def __del__(self):
+        if hasattr(self, "grpc_server") and self.grpc_server is not None:
+            self.grpc_server.stop(None)
+
+    # === BUCKET === #
+
+    def __check_bucket_metageneration(self, request, bucket, context):
+        metageneration = bucket.metadata.metageneration
+        match, not_match = testbench.generation.extract_precondition(
+            request, True, False, context
+        )
+        testbench.generation.check_precondition(
+            metageneration, match, not_match, True, context
+        )
+
+    def get_bucket_without_generation(self, bucket_name, context):
+        bucket = self.buckets.get(bucket_name)
+        if bucket is None:
+            testbench.error.notfound("Bucket %s" % bucket_name, context)
+        return bucket
+
+    def insert_bucket(self, request, bucket, context):
+        self.buckets[bucket.metadata.name] = bucket
+        self.objects[bucket.metadata.name] = {}
+        self.live_generations[bucket.metadata.name] = {}
+
+    def get_bucket(self, request, bucket_name, context):
+        bucket = self.get_bucket_without_generation(bucket_name, context)
+        self.__check_bucket_metageneration(request, bucket, context)
+        return bucket
+
+    def list_bucket(self, request, project_id, context):
+        if project_id is None or project_id.endswith("-"):
+            testbench.error.invalid("Project id %s" % project_id, context)
+        return self.buckets.values()
+
+    def delete_bucket(self, request, bucket_name, context):
+        bucket = self.get_bucket(request, bucket_name, context)
+        if len(self.live_generations[bucket.metadata.name]) > 0:
+            testbench.error.invalid("Deleting non-empty bucket", context)
+        del self.buckets[bucket.metadata.name]
+        del self.objects[bucket.metadata.name]
+        del self.live_generations[bucket.metadata.name]
+
+    def insert_test_bucket(self, context):
+        """Automatically create a bucket if needed.
+
+        Many of the integration tests for `google-cloud-cpp` assume a
+        well-known bucket already exists. This function creates a bucket
+        based on the `GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME`, which
+        also happens to be the environment variable used to configure this
+        bucket name in said integration tests."""
+        bucket_name = os.environ.get("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
+        if bucket_name is None:
+            return
+        if self.buckets.get(bucket_name) is None:
+            request = testbench.common.FakeRequest(
+                args={}, data=json.dumps({"name": bucket_name})
+            )
+            bucket_test, _ = gcs.bucket.Bucket.init(request, context)
+            self.insert_bucket(request, bucket_test, context)
+            bucket_test.metadata.metageneration = 4
+            bucket_test.metadata.versioning.enabled = True
+
+    # === OBJECT === #
+
+    def __get_bucket_for_object(self, bucket_name, context):
+        bucket = self.objects.get(bucket_name)
+        if bucket is None:
+            testbench.error.notfound("Bucket %s" % bucket_name, context)
+        return bucket
+
+    @classmethod
+    def __extract_list_object_request(cls, request, context):
+        delimiter, prefix, versions = "", "", False
+        start_offset, end_offset = "", None
+        include_trailing_delimiter = False
+        if context is not None:
+            delimiter = request.delimiter
+            prefix = request.prefix
+            versions = request.versions
+            include_trailing_delimiter = request.include_trailing_delimiter
+        else:
+            delimiter = request.args.get("delimiter", "")
+            prefix = request.args.get("prefix", "")
+            versions = request.args.get("versions", False, type=bool)
+            start_offset = request.args.get("startOffset", "")
+            end_offset = request.args.get("endOffset")
+            include_trailing_delimiter = request.args.get(
+                "includeTrailingDelimiter", False
+            )
+        return (
+            delimiter,
+            prefix,
+            versions,
+            start_offset,
+            end_offset,
+            include_trailing_delimiter,
+        )
+
+    def list_object(self, request, bucket_name, context):
+        bucket = self.__get_bucket_for_object(bucket_name, context)
+        (
+            delimiter,
+            prefix,
+            versions,
+            start_offset,
+            end_offset,
+            include_trailing_delimiter,
+        ) = self.__extract_list_object_request(request, context)
+        items = []
+        rest_onlys = []
+        prefixes = set()
+        for obj in bucket.values():
+            generation = obj.metadata.generation
+            name = obj.metadata.name
+            if not versions and generation != self.live_generations[bucket_name].get(
+                name
+            ):
+                continue
+            if name.find(prefix) != 0:
+                continue
+            if name < start_offset:
+                continue
+            if end_offset and name >= end_offset:
+                continue
+            delimiter_index = name.find(delimiter, len(prefix))
+            if delimiter != "" and delimiter_index > 0:
+                prefixes.add(name[: delimiter_index + 1])
+                if delimiter_index < len(name) - 1 or not include_trailing_delimiter:
+                    continue
+            items.append(obj.metadata)
+            rest_onlys.append(obj.rest_only)
+        return items, list(prefixes), rest_onlys
+
+    def check_object_generation(
+        self, request, bucket_name, object_name, is_source, context
+    ):
+        bucket = self.__get_bucket_for_object(bucket_name, context)
+        generation = testbench.generation.extract_generation(
+            request, is_source, context
+        )
+        if generation == 0:
+            generation = self.live_generations[bucket_name].get(object_name, 0)
+        match, not_match = testbench.generation.extract_precondition(
+            request, False, is_source, context
+        )
+        testbench.generation.check_precondition(
+            generation, match, not_match, False, context
+        )
+        blob = bucket.get("%s#%d" % (object_name, generation))
+        metageneration = blob.metadata.metageneration if blob is not None else None
+        match, not_match = testbench.generation.extract_precondition(
+            request, True, is_source, context
+        )
+        testbench.generation.check_precondition(
+            metageneration, match, not_match, True, context
+        )
+        return blob, generation
+
+    def get_object(self, request, bucket_name, object_name, is_source, context):
+        blob, generation = self.check_object_generation(
+            request, bucket_name, object_name, is_source, context
+        )
+        if blob is None:
+            if generation == 0:
+                testbench.error.notfound(
+                    "Live version of object %s" % object_name, context
+                )
+            else:
+                testbench.error.notfound(
+                    "Object %s with generation %d" % (object_name, generation), context
+                )
+        return blob
+
+    def insert_object(self, request, bucket_name, blob, context):
+        self.check_object_generation(
+            request, bucket_name, blob.metadata.name, False, context
+        )
+        bucket = self.__get_bucket_for_object(bucket_name, context)
+        name = blob.metadata.name
+        generation = blob.metadata.generation
+        bucket["%s#%d" % (name, generation)] = blob
+        self.live_generations[bucket_name][name] = generation
+
+    def delete_object(self, request, bucket_name, object_name, context):
+        _ = self.get_object(request, bucket_name, object_name, False, context)
+        generation = testbench.generation.extract_generation(request, False, context)
+        live_generation = self.live_generations[bucket_name].get(object_name)
+        if generation == 0 or live_generation == generation:
+            self.live_generations[bucket_name].pop(object_name, None)
+        if generation != 0:
+            del self.objects[bucket_name]["%s#%d" % (object_name, generation)]

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -12,17 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import json
 import os
-import uuid
-import re
+
+from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
 
 import gcs
 import testbench
-
-from schema import Schema, SchemaError, And, Use
-from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
 
 
 class Database:
@@ -47,13 +43,6 @@ class Database:
     @classmethod
     def init(cls):
         return cls({}, {}, {}, {}, {}, {}, [])
-
-    def raii(self, grpc_server):
-        self.grpc_server = grpc_server
-
-    def __del__(self):
-        if hasattr(self, "grpc_server") and self.grpc_server is not None:
-            self.grpc_server.stop(None)
 
     # === BUCKET === #
 
@@ -128,20 +117,13 @@ class Database:
         delimiter, prefix, versions = "", "", False
         start_offset, end_offset = "", None
         include_trailing_delimiter = False
-        if context is not None:
-            delimiter = request.delimiter
-            prefix = request.prefix
-            versions = request.versions
-            include_trailing_delimiter = request.include_trailing_delimiter
-        else:
-            delimiter = request.args.get("delimiter", "")
-            prefix = request.args.get("prefix", "")
-            versions = request.args.get("versions", False, type=bool)
-            start_offset = request.args.get("startOffset", "")
-            end_offset = request.args.get("endOffset")
-            include_trailing_delimiter = request.args.get(
-                "includeTrailingDelimiter", False
-            )
+        # TODO(#27) - restore gRPC support for listing objects?
+        delimiter = request.args.get("delimiter", "")
+        prefix = request.args.get("prefix", "")
+        versions = request.args.get("versions", False, type=bool)
+        start_offset = request.args.get("startOffset", "")
+        end_offset = request.args.get("endOffset")
+        include_trailing_delimiter = request.args.get("includeTrailingDelimiter", False)
         return (
             delimiter,
             prefix,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit test for testbench.database."""
+
+import json
+import unittest
+import os
+
+from werkzeug.test import create_environ
+from werkzeug.wrappers import Request
+
+import gcs
+import testbench
+
+
+class TestDatabaseBucket(unittest.TestCase):
+    def test_bucket_crud(self):
+        database = testbench.database.Database.init()
+        request = testbench.common.FakeRequest(
+            args={},
+            data=json.dumps({"name": "bucket-name"}),
+        )
+        bucket, _ = gcs.bucket.Bucket.init(request, None)
+        database.insert_bucket(request, bucket, None)
+        get_result = database.get_bucket(request, "bucket-name", None)
+        self.assertEqual(bucket.metadata, get_result.metadata)
+        list_result = database.list_bucket(request, "test-project-id", None)
+        names = {b.metadata.name for b in list_result}
+        self.assertEqual(names, {"bucket-name"})
+        database.delete_bucket(request, "bucket-name", None)
+        list_result = database.list_bucket(request, "test-project-id", None)
+        names = {b.metadata.name for b in list_result}
+        self.assertEqual(names, set())
+
+    def test_bucket_not_found(self):
+        database = testbench.database.Database.init()
+        with self.assertRaises(testbench.error.RestException) as rest:
+            request = testbench.common.FakeRequest(
+                args={},
+                data=json.dumps({"name": "bucket-name"}),
+            )
+            database.get_bucket(request, "bucket-name", None)
+        self.assertEqual(rest.exception.code, 404)
+
+    def test_list_bucket_invalid(self):
+        database = testbench.database.Database.init()
+        with self.assertRaises(testbench.error.RestException) as rest:
+            request = testbench.common.FakeRequest(
+                args={},
+                data=json.dumps({}),
+            )
+            database.list_bucket(request, "invalid-project-id-", None)
+        self.assertEqual(rest.exception.code, 400)
+
+    def test_delete_not_empty(self):
+        database = testbench.database.Database.init()
+        request = testbench.common.FakeRequest(
+            args={},
+            data=json.dumps({"name": "bucket-name"}),
+        )
+        bucket, _ = gcs.bucket.Bucket.init(request, None)
+        database.insert_bucket(request, bucket, None)
+        request = testbench.common.FakeRequest(
+            args={"name": "object"}, data=b"12345678", headers={}, environ={}
+        )
+        blob, _ = gcs.object.Object.init_media(request, bucket.metadata)
+        database.insert_object(request, "bucket-name", blob, None)
+        with self.assertRaises(testbench.error.RestException) as rest:
+            request = testbench.common.FakeRequest(
+                args={},
+                data=json.dumps({}),
+            )
+            database.delete_bucket(request, "bucket-name", None)
+        self.assertEqual(rest.exception.code, 400)
+
+    def test_insert_test_bucket(self):
+        database = testbench.database.Database.init()
+        request = testbench.common.FakeRequest(
+            args={},
+            data=json.dumps({}),
+        )
+        os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
+        database.insert_test_bucket(None)
+        names = {b.metadata.name for b in database.list_bucket(request, "", None)}
+        self.assertEqual(names, set())
+
+        os.environ["GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME"] = "test-bucket-1"
+        database.insert_test_bucket(None)
+        get_result = database.get_bucket(request, "test-bucket-1", None)
+        self.assertEqual(get_result.metadata.name, "test-bucket-1")
+
+
+class TestDatabaseObject(unittest.TestCase):
+    def setUp(self):
+        self.database = testbench.database.Database.init()
+        request = testbench.common.FakeRequest(
+            args={},
+            data=json.dumps({"name": "bucket-name"}),
+        )
+        self.bucket, _ = gcs.bucket.Bucket.init(request, None)
+        self.database.insert_bucket(request, self.bucket, None)
+
+    def test_object_crud(self):
+        request = testbench.common.FakeRequest(
+            args={"name": "object-name"}, data=b"12345678", headers={}, environ={}
+        )
+        blob, _ = gcs.object.Object.init_media(request, self.bucket.metadata)
+        self.database.insert_object(request, "bucket-name", blob, None)
+        get_result = self.database.get_object(
+            testbench.common.FakeRequest(args={}),
+            "bucket-name",
+            "object-name",
+            is_source=True,
+            context=None,
+        )
+        self.assertEqual(get_result.metadata, blob.metadata)
+        items, _, _ = self.database.list_object(
+            Request(create_environ(query_string={})), "bucket-name", None
+        )
+        names = {o.name for o in items}
+        self.assertEqual(names, {"object-name"})
+
+        self.bucket.metadata.versioning.enabled = True
+        for name in ["abc", "obaaa", "obzzz", "zzz", "object-name/qux", "object-name"]:
+            request = testbench.common.FakeRequest(
+                args={"name": name}, data=b"12345678", headers={}, environ={}
+            )
+            blob, _ = gcs.object.Object.init_media(request, self.bucket.metadata)
+            self.database.insert_object(request, "bucket-name", blob, None)
+
+        items, _, _ = self.database.list_object(
+            Request(
+                create_environ(
+                    query_string={
+                        "prefix": "ob",
+                        "startOffset": "obc",
+                        "endOffset": "obr",
+                        "delimiter": "/",
+                        "includeTrailingDelimiter": "false",
+                        "versions": "true",
+                    }
+                )
+            ),
+            "bucket-name",
+            None,
+        )
+        names = {o.name for o in items}
+        self.assertEqual(names, {"object-name"})
+
+        # Delete the latest version, listing without versions should not include the just deleted object.
+        self.database.delete_object(
+            testbench.common.FakeRequest(args={}), "bucket-name", "object-name", None
+        )
+        items, _, _ = self.database.list_object(
+            Request(create_environ(query_string={})), "bucket-name", None
+        )
+        names = {o.name for o in items}
+        self.assertNotIn("object-name", names)
+
+        # Delete all versions of all objects.
+        items, _, _ = self.database.list_object(
+            Request(create_environ(query_string={"versions": "true"})),
+            "bucket-name",
+            None,
+        )
+        for o in items:
+            self.database.delete_object(
+                testbench.common.FakeRequest(args={"generation": o.generation}),
+                o.bucket,
+                o.name,
+                None,
+            )
+        items, _, _ = self.database.list_object(
+            Request(create_environ(query_string={"versions": "true"})),
+            "bucket-name",
+            None,
+        )
+        self.assertEqual(set(), {o.name for o in items})
+
+    def test_get_object_not_found(self):
+        with self.assertRaises(testbench.error.RestException) as rest:
+            _ = self.database.get_object(
+                testbench.common.FakeRequest(args={}),
+                "bucket-name",
+                "object-name",
+                is_source=False,
+                context=None,
+            )
+        self.assertEqual(rest.exception.code, 404)
+
+        request = testbench.common.FakeRequest(
+            args={"name": "object-name"}, data=b"12345678", headers={}, environ={}
+        )
+        blob, _ = gcs.object.Object.init_media(request, self.bucket.metadata)
+        self.database.insert_object(request, "bucket-name", blob, None)
+        with self.assertRaises(testbench.error.RestException) as rest:
+            _ = self.database.get_object(
+                testbench.common.FakeRequest(
+                    args={"generation": blob.metadata.generation + 1}
+                ),
+                "bucket-name",
+                "object-name",
+                is_source=False,
+                context=None,
+            )
+        self.assertEqual(rest.exception.code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -135,7 +135,19 @@ class TestDatabaseObject(unittest.TestCase):
         self.assertEqual(names, {"object-name"})
 
         self.bucket.metadata.versioning.enabled = True
-        for name in ["abc", "obaaa", "obzzz", "zzz", "object-name/qux", "object-name"]:
+        for name in [
+            "abc",
+            "obaaa",
+            "obzzz",
+            "zzz",
+            "object-name",
+            "object-name/",
+            "object-name/qux",
+            "object-name/foo/bar/baz",
+            "object-name/foo/bar/",
+            "object-name/foo/bar",
+            "object-name/foo///",
+        ]:
             request = testbench.common.FakeRequest(
                 args={"name": name}, data=b"12345678", headers={}, environ={}
             )
@@ -150,7 +162,6 @@ class TestDatabaseObject(unittest.TestCase):
                         "startOffset": "obc",
                         "endOffset": "obr",
                         "delimiter": "/",
-                        "includeTrailingDelimiter": "false",
                         "versions": "true",
                     }
                 )
@@ -216,6 +227,15 @@ class TestDatabaseObject(unittest.TestCase):
                 "object-name",
                 is_source=False,
                 context=None,
+            )
+        self.assertEqual(rest.exception.code, 404)
+
+    def test_list_object_bucket_not_found(self):
+        with self.assertRaises(testbench.error.RestException) as rest:
+            _, _, _ = self.database.list_object(
+                Request(create_environ(query_string={})),
+                "invalid-bucket-name",
+                None,
             )
         self.assertEqual(rest.exception.code, 404)
 


### PR DESCRIPTION
testbench.database will hold all the resources (Bucket, Object, etc.) so
the Flask and gRPC applications can find them and implement the various
RPCs associated with them.

Part of the work for #24 