### PR TITLE
chore: remove clang-format from sync-repo settings

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,6 +10,5 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   requiredStatusCheckContexts:
     - cla/google
-    - clang-format
     - Format with psf-black
     - Unit Tests with Python 3.9


### PR DESCRIPTION
I am not sure why I added that.
