### PR TITLE
feat: add retry wrapper to emulator

### DIFF
--- a/emulator.py
+++ b/emulator.py
@@ -104,7 +104,9 @@ def create_retry_test():
     payload = json.loads(flask.request.data)
     test_instruction_set = payload.get("instructions", None)
     if not test_instruction_set:
-        return flask.Response("instructions is not defined", status=400)
+        return flask.Response(
+            "instructions is not defined", status=400, content_type="text/plain"
+        )
     retry_test = db.insert_retry_test(test_instruction_set)
     retry_test_response = json.dumps(retry_test)
     return flask.Response(

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -19,8 +19,11 @@ import json
 import random
 import re
 import scalpl
+import socket
 import struct
+import sys
 import types
+from flask import Response as FlaskResponse
 from google.protobuf import timestamp_pb2
 from requests_toolbelt import MultipartDecoder
 from requests_toolbelt.multipart.decoder import ImproperBodyPartContentException
@@ -336,6 +339,92 @@ def enforce_patch_override(request):
         and request.headers.get("X-Http-Method-Override", "") != "PATCH"
     ):
         testbench.error.notallowed(context=None)
+
+
+def __extract_data(data):
+    if isinstance(data, FlaskResponse):
+        return data.get_data()
+    if isinstance(data, dict):
+        return json.dumps(data)
+    return data
+
+
+def __wrap_in_response_instance(data, to_wrap):
+    if isinstance(data, FlaskResponse):
+        data.set_data(to_wrap)
+        return data
+    return FlaskResponse(to_wrap)
+
+
+def __get_streamer_response_fn(database, method, conn, test_id):
+    def response_handler(data):
+        def streamer():
+            database.dequeue_next_instruction(test_id, method)
+            d = __extract_data(data)
+            chunk_size = 4
+            for r in range(0, len(d), chunk_size):
+                if r >= 10:
+                    conn.close()
+                    sys.exit(1)
+                chunk_end = min(r + chunk_size, len(d))
+                yield d[r:chunk_end]
+
+        return __wrap_in_response_instance(data, streamer())
+
+    return response_handler
+
+
+def __get_default_response_fn(data):
+    return data
+
+
+def handle_retry_test_instruction(database, request, method):
+    test_id = request.headers.get("x-retry-test-id", None)
+    if not test_id or not database.has_instructions_retry_test(test_id, method):
+        return __get_default_response_fn
+    next_instruction = database.peek_next_instruction(test_id, method)
+    error_code_matches = testbench.common.retry_return_error_code.match(
+        next_instruction
+    )
+    if error_code_matches:
+        database.dequeue_next_instruction(test_id, method)
+        items = list(error_code_matches.groups())
+        error_code = items[0]
+        error_message = {
+            "error": {"message": "Retry Test: Caused a {}".format(error_code)}
+        }
+        testbench.error.generic(
+            msg=error_message, rest_code=error_code, grpc_code=None, context=None
+        )
+    retry_connection_matches = testbench.common.retry_return_error_connection.match(
+        next_instruction
+    )
+    if retry_connection_matches:
+        items = list(retry_connection_matches.groups())
+        # sys.exit(1) retains database state with more than 1 thread
+        if items[0] == "reset-connection":
+            database.dequeue_next_instruction(test_id, method)
+            fd = request.environ["gunicorn.socket"]
+            fd.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+            fd.close()
+            sys.exit(1)
+        elif items[0] == "broken-stream":
+            conn = request.environ["gunicorn.socket"]
+            return __get_streamer_response_fn(database, method, conn, test_id)
+    error_after_bytes_matches = testbench.common.retry_return_error_after_bytes.match(
+        next_instruction
+    )
+    if error_after_bytes_matches and method == "storage.objects.insert":
+        items = list(error_after_bytes_matches.groups())
+        error_code = items[0]
+        after_bytes = items[1]
+        # Upload failures should allow to not complete after certain bytes
+        upload_type = request.args.get("uploadType", None)
+        upload_id = request.args.get("upload_id", None)
+        if upload_type == "resumable" and upload_id is not None:
+            database.dequeue_next_instruction(test_id, method)
+            testbench.error.notallowed()
+    return __get_default_response_fn
 
 
 def rest_crc32c_to_proto(crc32c):

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -363,6 +363,7 @@ def handle_retry_test_instruction(database, request, method):
         testbench.error.generic(
             msg=error_message, rest_code=error_code, grpc_code=None, context=None
         )
+    return __get_default_response_fn
 
 
 def rest_crc32c_to_proto(crc32c):

--- a/testbench/error.py
+++ b/testbench/error.py
@@ -46,7 +46,7 @@ def _simple_json_error(msg):
     return json.dumps({"error": {"errors": [{"domain": "global", "message": msg}]}})
 
 
-def _generic(msg, rest_code, grpc_code, context):
+def generic(msg, rest_code, grpc_code, context):
     """Generate the appropriate error for REST or gRPC handlers."""
     if context is not None:
         context.abort(grpc_code, msg)
@@ -75,17 +75,17 @@ def csek(context, rest_code=400, grpc_code=grpc.StatusCode.INVALID_ARGUMENT):
             }
         }
     )
-    _generic(error_msg, rest_code, grpc_code, context)
+    generic(error_msg, rest_code, grpc_code, context)
 
 
 def invalid(msg, context, rest_code=400, grpc_code=grpc.StatusCode.INVALID_ARGUMENT):
     """A fairly generic error for invalid values in arguments."""
-    _generic(_simple_json_error("%s is invalid." % msg), rest_code, grpc_code, context)
+    generic(_simple_json_error("%s is invalid." % msg), rest_code, grpc_code, context)
 
 
 def missing(name, context, rest_code=400, grpc_code=grpc.StatusCode.INVALID_ARGUMENT):
     """Error returned when an argument or value is missing."""
-    _generic(_simple_json_error("Missing %s." % name), rest_code, grpc_code, context)
+    generic(_simple_json_error("Missing %s." % name), rest_code, grpc_code, context)
 
 
 def mismatch(
@@ -102,23 +102,23 @@ def mismatch(
         str(expect),
         str(actual),
     )
-    _generic(_simple_json_error(msg), rest_code, grpc_code, context)
+    generic(_simple_json_error(msg), rest_code, grpc_code, context)
 
 
 def notchanged(msg, context, rest_code=304, grpc_code=grpc.StatusCode.ABORTED):
     """Error returned when if*NotMatch or If-None-Match pre-conditions fail."""
-    _generic(
+    generic(
         _simple_json_error("%s validation failed." % msg), rest_code, grpc_code, context
     )
 
 
 def notfound(name, context, rest_code=404, grpc_code=grpc.StatusCode.NOT_FOUND):
     """Error returned when a resource (Object, Bucket, Notification, etc.) is not found."""
-    _generic(
+    generic(
         _simple_json_error("%s does not exist." % name), rest_code, grpc_code, context
     )
 
 
 def notallowed(context=None, rest_code=405, grpc_code=None):
     """Error returned when a method is not allowed."""
-    _generic(_simple_json_error("method is not allowed"), rest_code, grpc_code, context)
+    generic(_simple_json_error("method is not allowed"), rest_code, grpc_code, context)

--- a/testbench/generation.py
+++ b/testbench/generation.py
@@ -74,7 +74,7 @@ def extract_generation(request, is_source, context):
 def check_precondition(generation, match, not_match, is_meta, context):
     msg = "generation" if not is_meta else "metageneration"
     if generation is not None and not_match is not None and not_match == generation:
-        testbench.error._generic(
+        testbench.error.generic(
             "Precondition Failed (%s = %d vs %s_not_match = %d)"
             % (msg, generation, msg, not_match),
             304,
@@ -82,7 +82,7 @@ def check_precondition(generation, match, not_match, is_meta, context):
             context,
         )
     if generation is not None and match is not None and match != generation:
-        testbench.error._generic(
+        testbench.error.generic(
             "Precondition Failed (%s = %d vs %s_match = %d)"
             % (msg, generation, msg, match),
             412,

--- a/tests/test_emulator.py
+++ b/tests/test_emulator.py
@@ -94,7 +94,8 @@ class TestEmulator(unittest.TestCase):
         self.assertIn("id", create_rest)
 
         list_response = self.client.get(
-            "/storage/v1/b", query_string={"project": "test-project-unused"},
+            "/storage/v1/b",
+            query_string={"project": "test-project-unused"},
             headers={"x-retry-test-id": create_rest.get("id")},
         )
         self.assertEqual(list_response.status_code, 429, msg=list_response.data)

--- a/tests/test_emulator.py
+++ b/tests/test_emulator.py
@@ -81,6 +81,24 @@ class TestEmulator(unittest.TestCase):
         response = self.client.get("/retry_test/invalid-id")
         self.assertEqual(response.status_code, 404)
 
+    def test_retry_test_use(self):
+        response = self.client.post(
+            "/retry_test",
+            data=json.dumps({"instructions": {"storage.buckets.list": ["return-429"]}}),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            response.headers.get("content-type").startswith("application/json")
+        )
+        create_rest = json.loads(response.data)
+        self.assertIn("id", create_rest)
+
+        list_response = self.client.get(
+            "/storage/v1/b", query_string={"project": "test-project-unused"},
+            headers={"x-retry-test-id": create_rest.get("id")},
+        )
+        self.assertEqual(list_response.status_code, 429, msg=list_response.data)
+
     def test_bucket_crud(self):
         insert_response = self.client.post(
             "/storage/v1/b", data=json.dumps({"name": "bucket-name"})

--- a/tests/test_emulator.py
+++ b/tests/test_emulator.py
@@ -181,3 +181,7 @@ class TestEmulator(unittest.TestCase):
         list_rest = json.loads(list_response.data)
         names = [b.get("name") for b in list_rest.get("items")]
         self.assertEqual(names, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The emulator wraps each RPC with a "retry test", a mechanism to inject
failures and exercise the retry path in the client libraries.  This
change adds the wrapper to the existing RPCs.

Part of the work for #24 