### PR TITLE
fix: method names in retry_test wrapper

### DIFF
--- a/emulator.py
+++ b/emulator.py
@@ -396,7 +396,7 @@ def bucket_set_iam_policy(bucket_name):
 
 
 @gcs.route("/b/<bucket_name>/iam/testPermissions")
-@retry_test(method="storage.buckets.testIamPermission")
+@retry_test(method="storage.buckets.testIamPermissions")
 def bucket_test_iam_permissions(bucket_name):
     db.get_bucket(flask.request, bucket_name, None)
     permissions = flask.request.args.getlist("permissions")
@@ -405,7 +405,7 @@ def bucket_test_iam_permissions(bucket_name):
 
 
 @gcs.route("/b/<bucket_name>/lockRetentionPolicy", methods=["POST"])
-@retry_test(method="storage.buckets.lockRententionPolicy")
+@retry_test(method="storage.buckets.lockRetentionPolicy")
 def bucket_lock_retention_policy(bucket_name):
     bucket = db.get_bucket(flask.request, bucket_name, None)
     bucket.metadata.retention_policy.is_locked = True

--- a/tests/test_emulator_retry.py
+++ b/tests/test_emulator_retry.py
@@ -36,6 +36,63 @@ class TestEmulatorRetry(unittest.TestCase):
         response = self.client.get("/")
         self.assertEqual(response.data, b"OK")
 
+    def test_retry_test_supported_operations(self):
+        BUCKET_OPERATIONS = {
+            "storage.buckets." + op
+            for op in [
+                "list",
+                "insert",
+                "get",
+                "update",
+                "patch",
+                "delete",
+                "getIamPolicy",
+                "setIamPolicy",
+                "testIamPermissions",
+                "lockRetentionPolicy",
+            ]
+        }
+        BUCKET_ACL_OPERATIONS = {
+            "storage.bucket_acl." + op
+            for op in ["list", "insert", "get", "update", "patch", "delete"]
+        }
+        BUCKET_DEFAULT_OBJECT_ACL_OPERATIONS = {
+            "storage.default_object_acl." + op
+            for op in ["list", "insert", "get", "update", "patch", "delete"]
+        }
+        NOTIFICATION_OPERATIONS = {
+            "storage.notifications." + op for op in ["list", "insert", "get", "delete"]
+        }
+        OBJECT_OPERATIONS = {
+            "storage.objects." + op
+            for op in [
+                "list",
+                "insert",
+                "get",
+                "update",
+                "patch",
+                "delete",
+                "compose",
+                "copy",
+                "rewrite",
+            ]
+        }
+        OBJECT_ACL_OPERATIONS = {
+            "storage.object_acl." + op
+            for op in ["list", "insert", "get", "update", "patch", "delete"]
+        }
+        groups = {
+            "buckets": BUCKET_OPERATIONS,
+            "bucket_acl": BUCKET_ACL_OPERATIONS,
+            "bucket_default_object_acl": BUCKET_DEFAULT_OBJECT_ACL_OPERATIONS,
+            "notifications": NOTIFICATION_OPERATIONS,
+            "objects": OBJECT_OPERATIONS,
+            "object_acl": OBJECT_ACL_OPERATIONS,
+        }
+        all = set(emulator.db.supported_methods)
+        for name, operations in groups.items():
+            self.assertEqual(all, all | operations)
+
     def test_retry_test_crud(self):
         self.assertIn("storage.buckets.list", emulator.db.supported_methods)
         response = self.client.post(


### PR DESCRIPTION
I found a couple of methods with the wrong names: one a clear typo, the
onther (`Permission` vs. `Permission*s*`) may be argued both ways. The
plural form matches the name in:

https://cloud.google.com/storage/docs/json_api/v1/buckets/testIamPermissions

So I went with that.
