### PR TITLE
feat: add raise_error route

### DIFF
--- a/emulator.py
+++ b/emulator.py
@@ -43,6 +43,16 @@ def index():
     return "OK"
 
 
+@root.route("/raise_error")
+def raise_error():
+    etype = flask.request.args.get("etype")
+    msg = flask.request.args.get("msg", "")
+    if etype is not None:
+        raise TypeError(msg)
+    else:
+        raise Exception(msg)
+
+
 def xml_put_object(bucket_name, object_name):
     db.insert_test_bucket(None)
     bucket = db.get_bucket_without_generation(bucket_name, None).metadata

--- a/tests/test_emulator_retry.py
+++ b/tests/test_emulator_retry.py
@@ -35,10 +35,6 @@ class TestEmulatorRetry(unittest.TestCase):
         # Avoid magic buckets in the test
         os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
 
-    def test_root(self):
-        response = self.client.get("/")
-        self.assertEqual(response.data, b"OK")
-
     def test_retry_test_supported_operations(self):
         BUCKET_OPERATIONS = {
             "storage.buckets." + op

--- a/tests/test_emulator_root.py
+++ b/tests/test_emulator_root.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit test for the root paths in emulator.py."""
+
+import os
+import unittest
+
+import emulator
+
+
+class TestEmulatorRoot(unittest.TestCase):
+    def setUp(self):
+        emulator.db.clear()
+        self.client = emulator.server.test_client()
+        # Avoid magic buckets in the test
+        os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
+
+    def test_root(self):
+        response = self.client.get("/")
+        self.assertEqual(response.data, b"OK")
+
+    def test_raise_defaul(self):
+        response = self.client.get("/raise_error", query_string={"msg": "test-only"})
+        self.assertNotEqual(response.status_code, 200)
+        self.assertIn("test-only", response.data.decode("utf-8"))
+
+    def test_raise_type_error(self):
+        response = self.client.get(
+            "/raise_error", query_string={"etype": "type", "msg": "test-only"}
+        )
+        self.assertNotEqual(response.status_code, 200)
+        self.assertIn("test-only", response.data.decode("utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emulator_root.py
+++ b/tests/test_emulator_root.py
@@ -33,7 +33,7 @@ class TestEmulatorRoot(unittest.TestCase):
         response = self.client.get("/")
         self.assertEqual(response.data, b"OK")
 
-    def test_raise_defaul(self):
+    def test_raise_default(self):
         response = self.client.get("/raise_error", query_string={"msg": "test-only"})
         self.assertNotEqual(response.status_code, 200)
         self.assertIn("test-only", response.data.decode("utf-8"))


### PR DESCRIPTION
I am not sure where this is used (not in the C++ client library, and in
none of the existing tests), but it seems plausible that somehow it is
used in some other client library tests.

Part of the work for #24 
