### PR TITLE
chore: support Python < 3.9

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.6", "3.8", "3.9"]
     name: Unit Tests with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/tests/test_emulator_bucket.py
+++ b/tests/test_emulator_bucket.py
@@ -129,7 +129,7 @@ class TestEmulatorBucket(unittest.TestCase):
             response.headers.get("content-type").startswith("application/json")
         )
         insert_rest = json.loads(response.data)
-        self.assertEqual(insert_rest, insert_rest | insert_data)
+        self.assertEqual(insert_rest, {**insert_rest, **insert_data})
 
         response = self.client.get(
             "/storage/v1/b/bucket-name/acl/allAuthenticatedUsers"
@@ -200,7 +200,7 @@ class TestEmulatorBucket(unittest.TestCase):
             response.headers.get("content-type").startswith("application/json")
         )
         insert_rest = json.loads(response.data)
-        self.assertEqual(insert_rest, insert_rest | insert_data)
+        self.assertEqual(insert_rest, {**insert_rest, **insert_data})
 
         response = self.client.get(
             "/storage/v1/b/bucket-name/defaultObjectAcl/allAuthenticatedUsers"

--- a/tests/test_emulator_object_metadata.py
+++ b/tests/test_emulator_object_metadata.py
@@ -58,7 +58,7 @@ class TestEmulatorObjectMetadata(unittest.TestCase):
             "name": "fox.txt",
             "size": "%d" % len(payload),
         }
-        self.assertEqual(get_rest, get_rest | expected_fields)
+        self.assertEqual(get_rest, {**get_rest, **expected_fields})
 
         response = self.client.get(
             "/storage/v1/b/bucket-name/o/fox.txt", query_string={"alt": "media"}
@@ -83,7 +83,7 @@ class TestEmulatorObjectMetadata(unittest.TestCase):
         )
         patch_rest = json.loads(response.data)
         self.assertEqual(
-            patch_rest.get("metadata"), patch_rest.get("metadata") | metadata
+            patch_rest.get("metadata"), {**patch_rest.get("metadata"), **metadata}
         )
 
         update = patch_rest.copy()
@@ -103,7 +103,7 @@ class TestEmulatorObjectMetadata(unittest.TestCase):
         update_rest = json.loads(response.data)
         self.assertEqual(
             update_rest.get("metadata"),
-            update_rest.get("metadata") | {"key0": "updated-label0"},
+            {**update_rest.get("metadata"), **{"key0": "updated-label0"}},
         )
 
         response = self.client.get("/storage/v1/b/bucket-name/o")
@@ -145,7 +145,7 @@ class TestEmulatorObjectMetadata(unittest.TestCase):
             response.headers.get("content-type").startswith("application/json")
         )
         insert_rest = json.loads(response.data)
-        self.assertEqual(insert_rest, insert_rest | insert_data)
+        self.assertEqual(insert_rest, {**insert_rest, **insert_data})
 
         response = self.client.get(
             "/storage/v1/b/bucket-name/o/zebra/acl/allAuthenticatedUsers"

--- a/tests/test_emulator_object_special.py
+++ b/tests/test_emulator_object_special.py
@@ -193,7 +193,7 @@ class TestEmulatorObjectSpecial(unittest.TestCase):
         get_rest = json.loads(response.data)
 
         self.assertEqual(get_rest, copy_rest)
-        self.assertEqual(get_rest["metadata"], get_rest["metadata"] | metadata)
+        self.assertEqual(get_rest["metadata"], {**get_rest["metadata"], **metadata})
 
         response = self.client.get("/bucket-name/fox2")
         self.assertEqual(response.status_code, 200)
@@ -265,7 +265,7 @@ class TestEmulatorObjectSpecial(unittest.TestCase):
         get_rest = json.loads(response.data)
 
         self.assertEqual(get_rest, resource)
-        self.assertEqual(get_rest["metadata"], get_rest["metadata"] | metadata)
+        self.assertEqual(get_rest["metadata"], {**get_rest["metadata"], **metadata})
 
         response = self.client.get("/bucket-name/fox2")
         self.assertEqual(response.status_code, 200)

--- a/tests/test_emulator_object_upload.py
+++ b/tests/test_emulator_object_upload.py
@@ -195,7 +195,7 @@ class TestEmulatorObjectUpload(unittest.TestCase):
         insert_rest = json.loads(response.data)
         self.assertIn("metadata", insert_rest)
         insert_metadata = insert_rest.get("metadata")
-        self.assertEqual(insert_metadata, insert_metadata | {"key0": "label0"})
+        self.assertEqual(insert_metadata, {**insert_metadata, **{"key0": "label0"}})
 
         response = self.client.get("/storage/v1/b/bucket-name/o/zebra")
         self.assertEqual(response.status_code, 200)
@@ -256,7 +256,7 @@ class TestEmulatorObjectUpload(unittest.TestCase):
         insert_rest = json.loads(response.data)
         self.assertIn("metadata", insert_rest)
         insert_metadata = insert_rest.get("metadata")
-        self.assertEqual(insert_metadata, insert_metadata | {"key0": "label0"})
+        self.assertEqual(insert_metadata, {**insert_metadata, **{"key0": "label0"}})
 
         response = self.client.get("/storage/v1/b/bucket-name/o/zebra")
         self.assertEqual(response.status_code, 200)
@@ -332,7 +332,7 @@ class TestEmulatorObjectUpload(unittest.TestCase):
         insert_rest = json.loads(response.data)
         self.assertIn("metadata", insert_rest)
         insert_metadata = insert_rest.get("metadata")
-        self.assertEqual(insert_metadata, insert_metadata | {"key0": "label0"})
+        self.assertEqual(insert_metadata, {**insert_metadata, **{"key0": "label0"}})
 
         response = self.client.get("/storage/v1/b/bucket-name/o/empty")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Python < 3.9 lacks dict union operators:

https://www.python.org/dev/peps/pep-0584

All the alternatives are ugly (otherwise they would not have added the
operator!). I decided to use the `{**a, **b}` formulation.

Fixes #64 