### PR TITLE
cleanup: remove references to storage/v1 requests

### DIFF
--- a/gcs/bucket.py
+++ b/gcs/bucket.py
@@ -153,12 +153,8 @@ class Bucket:
     @classmethod
     def init(cls, request, context, rest_only=None):
         time_created = datetime.datetime.now()
-        metadata = None
-        if context is not None:
-            metadata = request.bucket
-        else:
-            metadata, rest_only = cls.__preprocess_rest(json.loads(request.data))
-            metadata = json_format.ParseDict(metadata, resources_pb2.Bucket())
+        metadata, rest_only = cls.__preprocess_rest(json.loads(request.data))
+        metadata = json_format.ParseDict(metadata, resources_pb2.Bucket())
         cls.__validate_bucket_name(metadata.name, context)
         default_projection = CommonEnums.Projection.NO_ACL
         if len(metadata.acl) != 0 or len(metadata.default_object_acl) != 0:
@@ -251,17 +247,13 @@ class Bucket:
         return self.iam_policy
 
     def set_iam_policy(self, request, context):
-        policy = None
-        if context is not None:
-            policy = request.iam_request.policy
-        else:
-            data = json.loads(request.data)
-            if "iam_request" in data:
-                data = data["iam_request"]["policy"]
-            data.pop("kind", None)
-            data.pop("etag", None)
-            data.pop("resourceId", None)
-            policy = json_format.ParseDict(data, policy_pb2.Policy())
+        data = json.loads(request.data)
+        if "iam_request" in data:
+            data = data["iam_request"]["policy"]
+        data.pop("kind", None)
+        data.pop("etag", None)
+        data.pop("resourceId", None)
+        policy = json_format.ParseDict(data, policy_pb2.Policy())
         self.iam_policy = policy
         self.iam_policy.etag = datetime.datetime.now().isoformat().encode("utf-8")
         return self.iam_policy
@@ -276,13 +268,9 @@ class Bucket:
         self.metadata.updated.FromDatetime(datetime.datetime.now())
 
     def update(self, request, context):
-        metadata = None
-        if context is not None:
-            metadata = request.metadata
-        else:
-            metadata, rest_only = self.__preprocess_rest(json.loads(request.data))
-            self.rest_only.update(rest_only)
-            metadata = json_format.ParseDict(metadata, resources_pb2.Bucket())
+        metadata, rest_only = self.__preprocess_rest(json.loads(request.data))
+        self.rest_only.update(rest_only)
+        metadata = json_format.ParseDict(metadata, resources_pb2.Bucket())
         self.__update_metadata(metadata, None)
         self.__insert_predefined_acl(
             metadata,
@@ -298,38 +286,34 @@ class Bucket:
     def patch(self, request, context):
         update_mask = field_mask_pb2.FieldMask()
         metadata = None
-        if context is not None:
-            metadata = request.metadata
-            update_mask = request.update_mask
-        else:
-            data = json.loads(request.data)
-            if "labels" in data:
-                if data["labels"] is None:
-                    self.metadata.labels.clear()
-                else:
-                    for key, value in data["labels"].items():
-                        if value is None:
-                            self.metadata.labels.pop(key, None)
-                        else:
-                            self.metadata.labels[key] = value
-            data.pop("labels", None)
-            data, rest_only = self.__preprocess_rest(data)
-            self.rest_only.update(rest_only)
-            metadata = json_format.ParseDict(data, resources_pb2.Bucket())
-            paths = set()
-            for key in testbench.common.nested_key(data):
-                key = testbench.common.to_snake_case(key)
-                head = key
-                for i, c in enumerate(key):
-                    if c == "." or c == "[":
-                        head = key[0:i]
-                        break
-                if head in Bucket.modifiable_fields:
-                    if "[" in key:
-                        paths.add(head)
+        data = json.loads(request.data)
+        if "labels" in data:
+            if data["labels"] is None:
+                self.metadata.labels.clear()
+            else:
+                for key, value in data["labels"].items():
+                    if value is None:
+                        self.metadata.labels.pop(key, None)
                     else:
-                        paths.add(key)
-            update_mask = field_mask_pb2.FieldMask(paths=list(paths))
+                        self.metadata.labels[key] = value
+        data.pop("labels", None)
+        data, rest_only = self.__preprocess_rest(data)
+        self.rest_only.update(rest_only)
+        metadata = json_format.ParseDict(data, resources_pb2.Bucket())
+        paths = set()
+        for key in testbench.common.nested_key(data):
+            key = testbench.common.to_snake_case(key)
+            head = key
+            for i, c in enumerate(key):
+                if c == "." or c == "[":
+                    head = key[0:i]
+                    break
+            if head in Bucket.modifiable_fields:
+                if "[" in key:
+                    paths.add(head)
+                else:
+                    paths.add(key)
+        update_mask = field_mask_pb2.FieldMask(paths=list(paths))
         self.__update_metadata(metadata, update_mask)
         self.__insert_predefined_acl(
             metadata,
@@ -368,33 +352,18 @@ class Bucket:
         return self.metadata.acl[index]
 
     def insert_acl(self, request, context):
-        entity, role = "", ""
-        if context is not None:
-            entity, role = (
-                request.bucket_access_control.entity,
-                request.bucket_access_control.role,
-            )
-        else:
-            payload = json.loads(request.data)
-            entity, role = payload["entity"], payload["role"]
+        payload = json.loads(request.data)
+        entity, role = payload["entity"], payload["role"]
         return self.__upsert_acl(entity, role, context)
 
     def update_acl(self, request, entity, context):
-        role = ""
-        if context is not None:
-            role = request.bucket_access_control.role
-        else:
-            payload = json.loads(request.data)
-            role = payload["role"]
+        payload = json.loads(request.data)
+        role = payload["role"]
         return self.__upsert_acl(entity, role, context)
 
     def patch_acl(self, request, entity, context):
-        role = ""
-        if context is not None:
-            role = request.bucket_access_control.role
-        else:
-            payload = json.loads(request.data)
-            role = payload["role"]
+        payload = json.loads(request.data)
+        role = payload["role"]
         return self.__upsert_acl(entity, role, context)
 
     def delete_acl(self, entity, context):
@@ -428,33 +397,18 @@ class Bucket:
         return self.metadata.default_object_acl[index]
 
     def insert_default_object_acl(self, request, context):
-        entity, role = "", ""
-        if context is not None:
-            entity, role = (
-                request.object_access_control.entity,
-                request.object_access_control.role,
-            )
-        else:
-            payload = json.loads(request.data)
-            entity, role = payload["entity"], payload["role"]
+        payload = json.loads(request.data)
+        entity, role = payload["entity"], payload["role"]
         return self.__upsert_default_object_acl(entity, role, context)
 
     def update_default_object_acl(self, request, entity, context):
-        role = ""
-        if context is not None:
-            role = request.object_access_control.role
-        else:
-            payload = json.loads(request.data)
-            role = payload["role"]
+        payload = json.loads(request.data)
+        role = payload["role"]
         return self.__upsert_default_object_acl(entity, role, context)
 
     def patch_default_object_acl(self, request, entity, context):
-        role = ""
-        if context is not None:
-            role = request.object_access_control.role
-        else:
-            payload = json.loads(request.data)
-            role = payload["role"]
+        payload = json.loads(request.data)
+        role = payload["role"]
         return self.__upsert_default_object_acl(entity, role, context)
 
     def delete_default_object_acl(self, entity, context):

--- a/testbench/acl.py
+++ b/testbench/acl.py
@@ -171,11 +171,7 @@ def extract_predefined_acl(request, is_destination, context):
 
 
 def extract_predefined_default_object_acl(request, context):
-    return (
-        request.args.get("predefinedDefaultObjectAcl", "")
-        if context is None
-        else request.predefined_default_object_acl
-    )
+    return request.args.get("predefinedDefaultObjectAcl", "")
 
 
 # === COMPUTE PREDEFINED ACL === #

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -19,8 +19,6 @@
 import unittest
 import testbench
 
-from werkzeug.test import create_environ
-from werkzeug.wrappers import Request
 from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
 from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
 
@@ -46,26 +44,6 @@ class TestACL(unittest.TestCase):
             checker(testbench.acl.get_canonical_entity(input))
 
     def test_extract_predefined_default_object_acl(self):
-        request = storage_pb2.InsertBucketRequest()
-        predefined_default_object_acl = (
-            testbench.acl.extract_predefined_default_object_acl(request, "")
-        )
-        self.assertEqual(
-            predefined_default_object_acl,
-            CommonEnums.PredefinedObjectAcl.PREDEFINED_OBJECT_ACL_UNSPECIFIED,
-        )
-
-        request.predefined_default_object_acl = (
-            CommonEnums.PredefinedObjectAcl.OBJECT_ACL_AUTHENTICATED_READ
-        )
-        predefined_default_object_acl = (
-            testbench.acl.extract_predefined_default_object_acl(request, "")
-        )
-        self.assertEqual(
-            predefined_default_object_acl,
-            CommonEnums.PredefinedObjectAcl.OBJECT_ACL_AUTHENTICATED_READ,
-        )
-
         request = testbench.common.FakeRequest(args={})
         predefined_default_object_acl = (
             testbench.acl.extract_predefined_default_object_acl(request, None)
@@ -79,30 +57,6 @@ class TestACL(unittest.TestCase):
         self.assertEqual(predefined_default_object_acl, "authenticatedRead")
 
     def test_extract_predefined_acl(self):
-        request = storage_pb2.InsertBucketRequest()
-        predefined_acl = testbench.acl.extract_predefined_acl(request, False, "")
-        self.assertEqual(
-            predefined_acl,
-            CommonEnums.PredefinedBucketAcl.PREDEFINED_BUCKET_ACL_UNSPECIFIED,
-        )
-
-        request.predefined_acl = (
-            CommonEnums.PredefinedBucketAcl.BUCKET_ACL_AUTHENTICATED_READ
-        )
-        predefined_acl = testbench.acl.extract_predefined_acl(request, False, "")
-        self.assertEqual(
-            predefined_acl,
-            CommonEnums.PredefinedBucketAcl.BUCKET_ACL_AUTHENTICATED_READ,
-        )
-
-        request = storage_pb2.CopyObjectRequest(
-            destination_predefined_acl=CommonEnums.PredefinedBucketAcl.BUCKET_ACL_PRIVATE
-        )
-        predefined_acl = testbench.acl.extract_predefined_acl(request, True, "")
-        self.assertEqual(
-            predefined_acl, CommonEnums.PredefinedBucketAcl.BUCKET_ACL_PRIVATE
-        )
-
         request = testbench.common.FakeRequest(args={})
         predefined_acl = testbench.acl.extract_predefined_acl(request, False, None)
         self.assertEqual(predefined_acl, "")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -105,17 +105,6 @@ class TestCommonUtils(unittest.TestCase):
         )
 
     def test_extract_projection(self):
-        request = storage_pb2.CopyObjectRequest()
-        projection = testbench.common.extract_projection(
-            request, CommonEnums.Projection.NO_ACL, ""
-        )
-        self.assertEqual(projection, CommonEnums.Projection.NO_ACL)
-        request.projection = CommonEnums.Projection.FULL
-        projection = testbench.common.extract_projection(
-            request, CommonEnums.Projection.NO_ACL, ""
-        )
-        self.assertEqual(projection, CommonEnums.Projection.FULL)
-
         request = testbench.common.FakeRequest(args={})
         projection = testbench.common.extract_projection(
             request, CommonEnums.Projection.NO_ACL, None

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -25,36 +25,6 @@ import testbench.generation
 
 class TestGeneration(unittest.TestCase):
     def test_extract_precondition(self):
-        request = storage_pb2.CopyObjectRequest(
-            if_generation_not_match={"value": 1},
-            if_metageneration_match={"value": 2},
-            if_metageneration_not_match={"value": 3},
-            if_source_generation_match={"value": 4},
-            if_source_generation_not_match={"value": 5},
-            if_source_metageneration_match={"value": 6},
-            if_source_metageneration_not_match={"value": 7},
-        )
-        match, not_match = testbench.generation.extract_precondition(
-            request, False, False, ""
-        )
-        self.assertIsNone(match)
-        self.assertEqual(not_match, 1)
-        match, not_match = testbench.generation.extract_precondition(
-            request, True, False, ""
-        )
-        self.assertEqual(match, 2)
-        self.assertEqual(not_match, 3)
-        match, not_match = testbench.generation.extract_precondition(
-            request, False, True, ""
-        )
-        self.assertEqual(match, 4)
-        self.assertEqual(not_match, 5)
-        match, not_match = testbench.generation.extract_precondition(
-            request, True, True, ""
-        )
-        self.assertEqual(match, 6)
-        self.assertEqual(not_match, 7)
-
         request = testbench.common.FakeRequest(
             args={
                 "ifGenerationNotMatch": 1,
@@ -95,10 +65,6 @@ class TestGeneration(unittest.TestCase):
         request.generation = 1
         generation = testbench.generation.extract_generation(request, False, "")
         self.assertEqual(generation, 1)
-
-        request = storage_pb2.CopyObjectRequest(source_generation=2)
-        generation = testbench.generation.extract_generation(request, True, "")
-        self.assertEqual(generation, 2)
 
         request = testbench.common.FakeRequest(args={})
         generation = testbench.generation.extract_generation(request, False, None)

--- a/tests/test_holder.py
+++ b/tests/test_holder.py
@@ -23,7 +23,6 @@ import unittest
 from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
 from google.cloud.storage_v1.proto import storage_resources_pb2 as resources_pb2
 from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
-from google.protobuf import json_format
 
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
@@ -183,8 +182,10 @@ class TestHolder(unittest.TestCase):
         upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
 
     def test_init_resumable_grpc(self):
-        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
-        bucket, _ = gcs.bucket.Bucket.init(request, "")
+        request = testbench.common.FakeRequest(
+            args={}, data=json.dumps({"name": "bucket-name"})
+        )
+        bucket, _ = gcs.bucket.Bucket.init(request, None)
         bucket = bucket.metadata
         insert_object_spec = storage_pb2.InsertObjectSpec(
             resource={"name": "object", "bucket": "bucket"},
@@ -227,8 +228,10 @@ class TestHolder(unittest.TestCase):
         self.assertEqual(projection, CommonEnums.Projection.FULL)
 
     def test_resumable_rest(self):
-        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
-        bucket, _ = gcs.bucket.Bucket.init(request, "")
+        request = testbench.common.FakeRequest(
+            args={}, data=json.dumps({"name": "bucket"})
+        )
+        bucket, _ = gcs.bucket.Bucket.init(request, None)
         bucket = bucket.metadata
         data = json.dumps(
             {
@@ -262,8 +265,10 @@ class TestHolder(unittest.TestCase):
             self.assertEqual("bytes=0-42", status.headers.get("Range", None))
 
     def test_rewrite_rest(self):
-        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
-        bucket, _ = gcs.bucket.Bucket.init(request, "")
+        request = testbench.common.FakeRequest(
+            args={}, data=json.dumps({"name": "bucket"})
+        )
+        bucket, _ = gcs.bucket.Bucket.init(request, None)
         bucket = bucket.metadata
         data = json.dumps({"name": "a"})
         environ = create_environ(


### PR DESCRIPTION
The storage/v2 protos do **not** include any requests to change metadata
in objects or buckets. This PR removes references to such requests, as
well as any code to support those RPCs.

Part of the work for #58 