### PR TITLE
cleanup: do not use gRPC projection enum

### DIFF
--- a/emulator.py
+++ b/emulator.py
@@ -22,7 +22,6 @@ from werkzeug import serving
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from google.cloud.storage_v1.proto import storage_resources_pb2 as resources_pb2
-from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
 from google.protobuf import json_format
 
 import gcs as gcs_type
@@ -183,9 +182,7 @@ def bucket_get(bucket_name):
     db.insert_test_bucket(None)
     db.insert_test_bucket(None)
     bucket = db.get_bucket(flask.request, bucket_name, None)
-    projection = testbench.common.extract_projection(
-        flask.request, CommonEnums.Projection.NO_ACL, None
-    )
+    projection = testbench.common.extract_projection(flask.request, "noAcl", None)
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(bucket.rest(), projection, fields)
 
@@ -196,9 +193,7 @@ def bucket_update(bucket_name):
     db.insert_test_bucket(None)
     bucket = db.get_bucket(flask.request, bucket_name, None)
     bucket.update(flask.request, None)
-    projection = testbench.common.extract_projection(
-        flask.request, CommonEnums.Projection.FULL, None
-    )
+    projection = testbench.common.extract_projection(flask.request, "full", None)
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(bucket.rest(), projection, fields)
 
@@ -209,9 +204,7 @@ def bucket_patch(bucket_name):
     testbench.common.enforce_patch_override(flask.request)
     bucket = db.get_bucket(flask.request, bucket_name, None)
     bucket.patch(flask.request, None)
-    projection = testbench.common.extract_projection(
-        flask.request, CommonEnums.Projection.FULL, None
-    )
+    projection = testbench.common.extract_projection(flask.request, "full", None)
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(bucket.rest(), projection, fields)
 
@@ -450,9 +443,7 @@ def object_list(bucket_name):
 def object_update(bucket_name, object_name):
     blob = db.get_object(flask.request, bucket_name, object_name, False, None)
     blob.update(flask.request, None)
-    projection = testbench.common.extract_projection(
-        flask.request, CommonEnums.Projection.FULL, None
-    )
+    projection = testbench.common.extract_projection(flask.request, "full", None)
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(
         blob.rest_metadata(), projection, fields
@@ -465,9 +456,7 @@ def object_patch(bucket_name, object_name):
     testbench.common.enforce_patch_override(flask.request)
     blob = db.get_object(flask.request, bucket_name, object_name, False, None)
     blob.patch(flask.request, None)
-    projection = testbench.common.extract_projection(
-        flask.request, CommonEnums.Projection.FULL, None
-    )
+    projection = testbench.common.extract_projection(flask.request, "full", None)
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(
         blob.rest_metadata(), projection, fields
@@ -487,9 +476,7 @@ def object_get(bucket_name, object_name):
     blob = db.get_object(flask.request, bucket_name, object_name, False, None)
     media = flask.request.args.get("alt", None)
     if media is None or media == "json":
-        projection = testbench.common.extract_projection(
-            flask.request, CommonEnums.Projection.NO_ACL, None
-        )
+        projection = testbench.common.extract_projection(flask.request, "noAcl", None)
         fields = flask.request.args.get("fields", None)
         return testbench.common.filter_response_rest(
             blob.rest_metadata(), projection, fields
@@ -815,7 +802,7 @@ def resumable_upload_chunk(bucket_name):
                 )
                 db.insert_object(upload.request, bucket_name, blob, None)
                 projection = testbench.common.extract_projection(
-                    upload.request, CommonEnums.Projection.NO_ACL, None
+                    upload.request, "noAcl", None
                 )
                 fields = upload.request.args.get("fields", None)
                 return testbench.common.filter_response_rest(
@@ -868,9 +855,7 @@ def resumable_upload_chunk(bucket_name):
         blob.metadata.metadata["x_emulator_upload"] = "resumable"
         blob.metadata.metadata["x_emulator_custom_header"] = str(custom_header_value)
         db.insert_object(upload.request, bucket_name, blob, None)
-        projection = testbench.common.extract_projection(
-            upload.request, CommonEnums.Projection.NO_ACL, None
-        )
+        projection = testbench.common.extract_projection(upload.request, "noAcl", None)
         fields = upload.request.args.get("fields", None)
         return testbench.common.filter_response_rest(
             blob.rest_metadata(), projection, fields

--- a/gcs/bucket.py
+++ b/gcs/bucket.py
@@ -156,9 +156,9 @@ class Bucket:
         metadata, rest_only = cls.__preprocess_rest(json.loads(request.data))
         metadata = json_format.ParseDict(metadata, resources_pb2.Bucket())
         cls.__validate_bucket_name(metadata.name, context)
-        default_projection = CommonEnums.Projection.NO_ACL
+        default_projection = "noAcl"
         if len(metadata.acl) != 0 or len(metadata.default_object_acl) != 0:
-            default_projection = CommonEnums.Projection.FULL
+            default_projection = "full"
         is_uniform = metadata.iam_configuration.uniform_bucket_level_access.enabled
         metadata.iam_configuration.uniform_bucket_level_access.enabled = False
         if len(metadata.acl) == 0:

--- a/gcs/object.py
+++ b/gcs/object.py
@@ -134,12 +134,12 @@ class Object:
             testbench.csek.check(algorithm, key_b64, key_sha256_b64, context)
             metadata.customer_encryption.encryption_algorithm = algorithm
             metadata.customer_encryption.key_sha256 = key_sha256_b64
-        default_projection = CommonEnums.Projection.NO_ACL
+        default_projection = "noAcl"
         is_uniform = bucket.iam_configuration.uniform_bucket_level_access.enabled
         # TODO(#27) - this is probably a bug, cleanup once we move all the code
         bucket.iam_configuration.uniform_bucket_level_access.enabled = False
         if len(metadata.acl) != 0:
-            default_projection = CommonEnums.Projection.FULL
+            default_projection = "full"
         else:
             predefined_acl = testbench.acl.extract_predefined_acl(
                 request, is_destination, context

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -299,13 +299,9 @@ def extract_media(request):
 
 def extract_projection(request, default, context):
     if context is not None:
-        return request.projection if request.projection != 0 else default
-    else:
-        projection_map = ["noAcl", "full"]
-        projection = request.args.get("projection")
-        return (
-            projection if projection in projection_map else projection_map[default - 1]
-        )
+        return default
+    projection = request.args.get("projection")
+    return projection if projection is not None else default
 
 
 # === DATA === #

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -20,7 +20,6 @@ import json
 import unittest
 
 from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
-from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
 from google.protobuf import json_format
 
 import gcs

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -23,7 +23,6 @@ import unittest
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
 from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
-from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
 
 import testbench
 
@@ -106,14 +105,10 @@ class TestCommonUtils(unittest.TestCase):
 
     def test_extract_projection(self):
         request = testbench.common.FakeRequest(args={})
-        projection = testbench.common.extract_projection(
-            request, CommonEnums.Projection.NO_ACL, None
-        )
+        projection = testbench.common.extract_projection(request, "noAcl", None)
         self.assertEqual(projection, "noAcl")
         request.args["projection"] = "full"
-        projection = testbench.common.extract_projection(
-            request, CommonEnums.Projection.NO_ACL, None
-        )
+        projection = testbench.common.extract_projection(request, "noAcl", None)
         self.assertEqual(projection, "full")
 
     def test_filter_response_rest(self):

--- a/tests/test_holder.py
+++ b/tests/test_holder.py
@@ -193,7 +193,6 @@ class TestHolder(unittest.TestCase):
             if_generation_not_match={"value": 1},
             if_metageneration_match={"value": 2},
             if_metageneration_not_match={"value": 3},
-            projection=CommonEnums.Projection.FULL,
         )
         request = storage_pb2.InsertObjectRequest(
             insert_object_spec=insert_object_spec, write_offset=0
@@ -224,8 +223,6 @@ class TestHolder(unittest.TestCase):
         )
         self.assertEqual(match, 2)
         self.assertEqual(not_match, 3)
-        projection = testbench.common.extract_projection(upload.request, False, "")
-        self.assertEqual(projection, CommonEnums.Projection.FULL)
 
     def test_resumable_rest(self):
         request = testbench.common.FakeRequest(


### PR DESCRIPTION
The storage/v2 protos do not have an enum for projections. Remove it now
to make future PRs smaller.

Part of the work for #58