### PR TITLE
test: verify hmacKeys fault injection is configured

### DIFF
--- a/tests/test_emulator_retry.py
+++ b/tests/test_emulator_retry.py
@@ -81,8 +81,7 @@ class TestEmulatorRetry(unittest.TestCase):
             "storage.object_acl." + op
             for op in ["list", "insert", "get", "update", "patch", "delete"]
         }
-        PROJECT_OPERATIONS = set({"storage.serviceaccount.get"})
-        HMAC_KEY_OPERATIONS = {
+        PROJECT_OPERATIONS = {"storage.serviceaccount.get"} | {
             "storage.hmacKey." + op
             for op in [
                 "create",
@@ -100,7 +99,6 @@ class TestEmulatorRetry(unittest.TestCase):
             "objects": OBJECT_OPERATIONS,
             "object_acl": OBJECT_ACL_OPERATIONS,
             "project": PROJECT_OPERATIONS,
-            "hmacKey": HMAC_KEY_OPERATIONS,
         }
         all = set(emulator.db.supported_methods)
         for name, operations in groups.items():


### PR DESCRIPTION
@Breathtender I forgot to ask for this test in #74. But as I write this, I realized you named the functions `storage.hmacKey.*` (singular) while all the existing functions are plural (`storage.objects.*`, `storage.buckets.*`) is it too late to change it?

I can fix that in a follow up PR, if it is not going to disrupt things too much.
