### PR TITLE
cleanup: use storage/v2 bucket names

### DIFF
--- a/emulator.py
+++ b/emulator.py
@@ -727,7 +727,7 @@ def object_insert(bucket_name):
         blob, projection = gcs_type.object.Object.init_media(flask.request, bucket)
     elif upload_type == "multipart":
         blob, projection = gcs_type.object.Object.init_multipart(flask.request, bucket)
-    db.insert_object(flask.request, bucket.name, blob, None)
+    db.insert_object(flask.request, bucket_name, blob, None)
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(
         blob.rest_metadata(), projection, fields

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -604,3 +604,16 @@ def rest_patch(target: dict, patch: dict, path: list = None) -> dict:
         else:
             raise Exception("Type mismatch at %s" % ".".join(location))
     return patched
+
+
+def bucket_name_from_proto(bucket_name):
+    if bucket_name is None:
+        return None
+    prefix = "projects/_/buckets/"
+    if bucket_name.startswith(prefix):
+        return bucket_name[len(prefix) :]
+    return bucket_name[:]
+
+
+def bucket_name_to_proto(bucket_name):
+    return "projects/_/buckets/" + bucket_name

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -68,8 +68,13 @@ class Database:
             metageneration, match, not_match, True, context
         )
 
+    def __bucket_key(self, bucket_name, context):
+        if context is None:
+            return testbench.common.bucket_name_to_proto(bucket_name)
+        return bucket_name
+
     def get_bucket_without_generation(self, bucket_name, context):
-        bucket = self.buckets.get(bucket_name)
+        bucket = self.buckets.get(self.__bucket_key(bucket_name, context))
         if bucket is None:
             testbench.error.notfound("Bucket %s" % bucket_name, context)
         return bucket
@@ -108,7 +113,7 @@ class Database:
         bucket_name = os.environ.get("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
         if bucket_name is None:
             return
-        if self.buckets.get(bucket_name) is None:
+        if self.buckets.get(self.__bucket_key(bucket_name, context)) is None:
             request = testbench.common.FakeRequest(
                 args={}, data=json.dumps({"name": bucket_name})
             )
@@ -120,7 +125,7 @@ class Database:
     # === OBJECT === #
 
     def __get_bucket_for_object(self, bucket_name, context):
-        bucket = self.objects.get(bucket_name)
+        bucket = self.objects.get(self.__bucket_key(bucket_name, context))
         if bucket is None:
             testbench.error.notfound("Bucket %s" % bucket_name, context)
         return bucket
@@ -146,6 +151,18 @@ class Database:
             include_trailing_delimiter,
         )
 
+    def __get_live_generation(self, bucket_name, object_name, context):
+        bucket_key = self.__bucket_key(bucket_name, context)
+        return self.live_generations[bucket_key].get(object_name)
+
+    def __set_live_generation(self, bucket_name, object_name, generation, context):
+        bucket_key = self.__bucket_key(bucket_name, context)
+        self.live_generations[bucket_key][object_name] = generation
+
+    def __del_live_generation(self, bucket_name, object_name, context):
+        bucket_key = self.__bucket_key(bucket_name, context)
+        self.live_generations[bucket_key].pop(object_name, None)
+
     def list_object(self, request, bucket_name, context):
         bucket = self.__get_bucket_for_object(bucket_name, context)
         (
@@ -161,8 +178,8 @@ class Database:
         for obj in bucket.values():
             generation = obj.metadata.generation
             name = obj.metadata.name
-            if not versions and generation != self.live_generations[bucket_name].get(
-                name
+            if not versions and generation != self.__get_live_generation(
+                bucket_name, name, context
             ):
                 continue
             if name.find(prefix) != 0:
@@ -187,7 +204,9 @@ class Database:
             request, is_source, context
         )
         if generation == 0:
-            generation = self.live_generations[bucket_name].get(object_name, 0)
+            generation = self.__get_live_generation(bucket_name, object_name, context)
+            if generation is None:
+                generation = 0
         match, not_match = testbench.generation.extract_precondition(
             request, False, is_source, context
         )
@@ -227,16 +246,18 @@ class Database:
         name = blob.metadata.name
         generation = blob.metadata.generation
         bucket["%s#%d" % (name, generation)] = blob
-        self.live_generations[bucket_name][name] = generation
+        self.__set_live_generation(bucket_name, name, generation, context)
 
     def delete_object(self, request, bucket_name, object_name, context):
         _ = self.get_object(request, bucket_name, object_name, False, context)
         generation = testbench.generation.extract_generation(request, False, context)
-        live_generation = self.live_generations[bucket_name].get(object_name)
+        live_generation = self.__get_live_generation(bucket_name, object_name, context)
         if generation == 0 or live_generation == generation:
-            self.live_generations[bucket_name].pop(object_name, None)
+            self.__del_live_generation(bucket_name, object_name, context)
         if generation != 0:
-            del self.objects[bucket_name]["%s#%d" % (object_name, generation)]
+            self.objects[self.__bucket_key(bucket_name, context)].pop(
+                "%s#%d" % (object_name, generation), None
+            )
 
     # === UPLOAD === #
 

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -69,9 +69,9 @@ class Database:
         )
 
     def __bucket_key(self, bucket_name, context):
-        if context is None:
-            return testbench.common.bucket_name_to_proto(bucket_name)
-        return bucket_name
+        # TODO(#58) - remove this assert when we support gRPC operations
+        assert context is None
+        return testbench.common.bucket_name_to_proto(bucket_name)
 
     def get_bucket_without_generation(self, bucket_name, context):
         bucket = self.buckets.get(self.__bucket_key(bucket_name, context))

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -73,7 +73,8 @@ class TestBucket(unittest.TestCase):
             data=json.dumps({"name": "bucket"}),
         )
         bucket, _ = gcs.bucket.Bucket.init(request, None)
-        self.assertEqual(bucket.metadata.name, "bucket")
+        self.assertEqual(bucket.metadata.name, "projects/_/buckets/bucket")
+        self.assertEqual(bucket.metadata.bucket_id, "bucket")
         self.assertLess(0, bucket.metadata.metageneration)
 
     def test_init_validates_names(self):
@@ -83,7 +84,8 @@ class TestBucket(unittest.TestCase):
         )
         bucket, _ = gcs.bucket.Bucket.init(request, None)
         self.assertEqual(
-            bucket.metadata.name, "short.names.for.domain.buckets.example.com"
+            bucket.metadata.name,
+            "projects/_/buckets/short.names.for.domain.buckets.example.com",
         )
         invalid_names = [
             "goog-is-not-a-valid-prefix",
@@ -157,7 +159,7 @@ class TestBucket(unittest.TestCase):
         bucket, projection = gcs.bucket.Bucket.init(request, None)
         self.assertEqual(projection, "full")
         # Verify the name is stored in the correct format for gRPC
-        self.assertEqual(bucket.metadata.name, "test-bucket-name")
+        self.assertEqual(bucket.metadata.name, "projects/_/buckets/test-bucket-name")
         bucket_rest = bucket.rest()
         # Some fields must exist in the REST message
         for required in ["metageneration", "kind", "name"]:
@@ -206,7 +208,7 @@ class TestBucket(unittest.TestCase):
             ),
         )
         bucket, projection = gcs.bucket.Bucket.init(request, None)
-        self.assertEqual(bucket.metadata.name, "bucket")
+        self.assertEqual(bucket.metadata.name, "projects/_/buckets/bucket")
         self.assertEqual(projection, "full")
 
         def acl_sort(x):
@@ -289,7 +291,7 @@ class TestBucket(unittest.TestCase):
         )
         bucket.patch(request, None)
         # REST should only update modifiable field.
-        self.assertEqual(bucket.metadata.name, "bucket")
+        self.assertEqual(bucket.metadata.name, "projects/_/buckets/bucket")
         # REST can update a part of map field.
         self.assertIsNone(bucket.metadata.labels.get("init"))
         self.assertEqual(bucket.metadata.labels.get("patch"), "true")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -411,6 +411,28 @@ class TestCommonUtils(unittest.TestCase):
             testbench.common.rest_patch({"a": {"b": "c"}}, {"a": {"b": {"ooops": 7}}})
         self.assertIn("Type mismatch at a.b", "%s" % ex.exception)
 
+    def test_bucket_to_from_proto(self):
+        self.assertIsNone(testbench.common.bucket_name_from_proto(None))
+        self.assertEqual(
+            "bucket-name", testbench.common.bucket_name_from_proto("bucket-name")
+        )
+        self.assertEqual(
+            "bucket-name",
+            testbench.common.bucket_name_from_proto("projects/_/buckets/bucket-name"),
+        )
+        self.assertEqual(
+            "bucket-name",
+            testbench.common.bucket_name_from_proto(
+                testbench.common.bucket_name_to_proto("bucket-name")
+            ),
+        )
+        self.assertEqual(
+            "bucket.example.com",
+            testbench.common.bucket_name_from_proto(
+                testbench.common.bucket_name_to_proto("bucket.example.com")
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -39,7 +39,7 @@ class TestDatabaseBucket(unittest.TestCase):
         get_result = database.get_bucket(request, "bucket-name", None)
         self.assertEqual(bucket.metadata, get_result.metadata)
         list_result = database.list_bucket(request, "test-project-id", None)
-        names = {b.metadata.name for b in list_result}
+        names = {b.metadata.bucket_id for b in list_result}
         self.assertEqual(names, {"bucket-name"})
         database.delete_bucket(request, "bucket-name", None)
         list_result = database.list_bucket(request, "test-project-id", None)
@@ -101,7 +101,7 @@ class TestDatabaseBucket(unittest.TestCase):
         os.environ["GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME"] = "test-bucket-1"
         database.insert_test_bucket(None)
         get_result = database.get_bucket(request, "test-bucket-1", None)
-        self.assertEqual(get_result.metadata.name, "test-bucket-1")
+        self.assertEqual(get_result.metadata.bucket_id, "test-bucket-1")
 
 
 class TestDatabaseObject(unittest.TestCase):
@@ -191,7 +191,7 @@ class TestDatabaseObject(unittest.TestCase):
         for o in items:
             self.database.delete_object(
                 testbench.common.FakeRequest(args={"generation": o.generation}),
-                o.bucket,
+                "bucket-name",
                 o.name,
                 None,
             )

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -44,6 +44,7 @@ class TestObject(unittest.TestCase):
             args={"name": "object"}, data=b"12345678", headers={}, environ={}
         )
         blob, _ = gcs.object.Object.init_media(request, self.bucket.metadata)
+        self.assertEqual(blob.metadata.bucket, "projects/_/buckets/bucket")
         self.assertEqual(blob.metadata.name, "object")
         self.assertEqual(blob.media, b"12345678")
 
@@ -72,6 +73,7 @@ class TestObject(unittest.TestCase):
             environ={},
         )
         blob, _ = gcs.object.Object.init_multipart(request, self.bucket.metadata)
+        self.assertEqual(blob.metadata.bucket, "projects/_/buckets/bucket")
         self.assertEqual(blob.metadata.name, "object")
         self.assertEqual(blob.media, b"123456789")
         self.assertEqual(blob.metadata.metadata["key"], "value")
@@ -297,7 +299,7 @@ class TestObject(unittest.TestCase):
             False,
             "FakeContext",
         )
-        self.assertEqual(blob.metadata.bucket, "bucket")
+        self.assertEqual(blob.metadata.bucket, "projects/_/buckets/bucket")
         self.assertEqual(blob.metadata.name, "test-object-name")
         self.assertEqual(blob.media, b"123456789")
 
@@ -447,7 +449,7 @@ class TestObject(unittest.TestCase):
             environ={},
         )
         blob, _ = gcs.object.Object.init_multipart(request, self.bucket.metadata)
-        self.assertEqual(blob.metadata.bucket, "bucket")
+        self.assertEqual(blob.metadata.bucket, "projects/_/buckets/bucket")
         self.assertEqual(blob.metadata.name, "test-object-name")
         self.assertEqual(blob.media, b"123456789")
         self.assertEqual(blob.metadata.metadata["method"], "rest")


### PR DESCRIPTION
The gRPC uses `projects/_/buckets/{bucket}` for bucket names, and uses
`{bucket}` for the `bucket_id` field. If we are going to keep the data
in proto form, I think it should use the proto values too.

Part of the work for #58 