### PR TITLE
feat: support functions for storage/v2 gRPC writes

### DIFF
--- a/tests/test_emulator_retry.py
+++ b/tests/test_emulator_retry.py
@@ -20,7 +20,6 @@ import json
 import os
 import re
 import unittest
-from unittest.mock import MagicMock, patch
 
 import emulator
 import testbench

--- a/tests/test_holder.py
+++ b/tests/test_holder.py
@@ -22,10 +22,9 @@ import hashlib
 import flask
 import json
 import unittest
-
+import unittest.mock
 from google.storage.v2 import storage_pb2
-from google.protobuf import json_format
-
+import grpc
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
 
@@ -152,7 +151,7 @@ class TestHolder(unittest.TestCase):
             content_type="application/json",
             method="POST",
         )
-        upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        _ = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
 
         data = json.dumps({"name": "a"})
         environ = create_environ(
@@ -162,7 +161,7 @@ class TestHolder(unittest.TestCase):
             content_type="application/json",
             method="POST",
         )
-        upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        _ = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
 
         environ = create_environ(
             base_url="http://localhost:8080",
@@ -170,7 +169,7 @@ class TestHolder(unittest.TestCase):
             content_type="application/json",
             method="POST",
         )
-        upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        _ = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
 
         data = json.dumps({"name": None})
         environ = create_environ(
@@ -181,50 +180,101 @@ class TestHolder(unittest.TestCase):
             content_type="application/json",
             method="POST",
         )
-        upload = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
+        _ = gcs.holder.DataHolder.init_resumable_rest(Request(environ), bucket)
 
-    def test_init_resumable_grpc(self):
+    def test_resumable_rest(self):
         request = testbench.common.FakeRequest(
-            args={}, data=json.dumps({"name": "bucket-name"})
+            args={}, data=json.dumps({"name": "bucket"})
         )
         bucket, _ = gcs.bucket.Bucket.init(request, None)
-        spec = storage_pb2.WriteObjectSpec(
-            resource={"name": "object", "bucket": "projects/_/buckets/bucket-name"},
-            predefined_acl=storage_pb2.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE,
-            if_generation_not_match=1,
-            if_metageneration_match=2,
-            if_metageneration_not_match=3,
+        data = json.dumps(
+            {
+                # Empty payload checksums
+                "crc32c": "AAAAAA==",
+                "md5Hash": "1B2M2Y8AsgTpgAmY7PhCfg==",
+                "name": "test-object-name",
+            }
         )
-        request = storage_pb2.WriteObjectRequest(write_object_spec=spec, write_offset=0)
-        upload = gcs.holder.DataHolder.init_resumable_grpc(request, bucket.metadata, "")
-        # Verify the annotations inserted by the emulator.
-        annotations = upload.metadata.metadata
-        self.assertGreaterEqual(
-            set(["x_emulator_upload", "x_emulator_no_crc32c", "x_emulator_no_md5"]),
-            set(annotations.keys()),
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            content_length=len(data),
+            data=data,
+            content_type="application/json",
+            method="POST",
         )
-        # Clear any annotations created by the emulator
-        upload.metadata.metadata.clear()
+        upload = gcs.holder.DataHolder.init_resumable_rest(
+            Request(environ), bucket.metadata
+        )
+        self.assertEqual(upload.metadata.name, "test-object-name")
+        self.assertEqual(upload.metadata.checksums.crc32c, 0)
         self.assertEqual(
-            upload.metadata,
-            storage_pb2.Object(name="object", bucket="projects/_/buckets/bucket-name"),
-        )
-        predefined_acl = testbench.acl.extract_predefined_acl(upload.request, False, "")
-        self.assertEqual(
-            predefined_acl, storage_pb2.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE
+            upload.metadata.checksums.md5_hash,
+            base64.b64decode("1B2M2Y8AsgTpgAmY7PhCfg=="),
         )
         match, not_match = testbench.generation.extract_precondition(
             upload.request, False, False, None
         )
         self.assertIsNone(match)
-        self.assertEqual(not_match, 1)
-        match, not_match = testbench.generation.extract_precondition(
-            upload.request, True, False, None
-        )
-        self.assertEqual(match, 2)
-        self.assertEqual(not_match, 3)
+        self.assertIsNone(not_match)
 
-    def test_init_resumable_grpc_with_checksums(self):
+        app = flask.Flask(__name__)
+        with app.test_request_context():
+            status = upload.resumable_status_rest()
+            self.assertEqual(status.status_code, 308)
+            # Simulate a previous chunk upload
+            upload.media = "The quick brown fox jumps over the lazy dog"
+            status = upload.resumable_status_rest()
+            self.assertEqual(status.status_code, 308)
+            self.assertIn("Range", status.headers)
+            self.assertEqual("bytes=0-42", status.headers.get("Range", None))
+
+    def test_init_object_write_grpc_non_resumable(self):
+        line = b"The quick brown fox jumps over the lazy dog\n"
+        request = testbench.common.FakeRequest(
+            args={}, data=json.dumps({"name": "bucket-name"})
+        )
+        bucket, _ = gcs.bucket.Bucket.init(request, None)
+
+        r1 = storage_pb2.WriteObjectRequest(
+            write_object_spec=storage_pb2.WriteObjectSpec(
+                resource={"name": "object", "bucket": "projects/_/buckets/bucket-name"},
+            ),
+            write_offset=0,
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=False,
+        )
+        r2 = storage_pb2.WriteObjectRequest(
+            write_offset=len(line),
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=False,
+        )
+        r3 = storage_pb2.WriteObjectRequest(
+            write_offset=2 * len(line),
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=True,
+        )
+        context = unittest.mock.Mock()
+        db = unittest.mock.Mock()
+        db.get_bucket_without_generation = unittest.mock.MagicMock(return_value=bucket)
+        upload, is_resumable = gcs.holder.DataHolder.init_write_object_grpc(
+            db, [r1, r2, r3], context
+        )
+        self.assertIsNotNone(upload)
+        self.assertFalse(is_resumable)
+        self.assertEqual(upload.media, b"".join(3 * [line]))
+        self.assertEqual(upload.metadata.name, "object")
+        self.assertEqual(upload.metadata.bucket, "projects/_/buckets/bucket-name")
+        db.get_bucket_without_generation.assert_called_once_with(
+            "projects/_/buckets/bucket-name", context
+        )
+
+    def test_init_object_write_grpc_checksums(self):
         media = b"The quick brown fox jumps over the lazy dog"
         proto_crc32c = crc32c.crc32c(media)
         proto_md5_hash = hashlib.md5(media).digest()
@@ -274,9 +324,16 @@ class TestHolder(unittest.TestCase):
                 write_object_spec=spec,
                 write_offset=0,
                 object_checksums=test["checksums"],
+                finish_write=True,
             )
-            upload = gcs.holder.DataHolder.init_resumable_grpc(
-                request, bucket.metadata, ""
+
+            context = unittest.mock.Mock()
+            db = unittest.mock.Mock()
+            db.get_bucket_without_generation = unittest.mock.MagicMock(
+                return_value=bucket
+            )
+            upload, is_resumable = gcs.holder.DataHolder.init_write_object_grpc(
+                db, [request], context
             )
             # Verify the annotations inserted by the emulator.
             annotations = upload.metadata.metadata
@@ -288,46 +345,287 @@ class TestHolder(unittest.TestCase):
                 msg="Testing with %s checksums" % name,
             )
 
-    def test_resumable_rest(self):
+    def test_init_resumable_grpc(self):
         request = testbench.common.FakeRequest(
-            args={}, data=json.dumps({"name": "bucket"})
+            args={}, data=json.dumps({"name": "bucket-name"})
         )
         bucket, _ = gcs.bucket.Bucket.init(request, None)
-        data = json.dumps(
-            {
-                # Empty payload checksums
-                "crc32c": "AAAAAA==",
-                "md5Hash": "1B2M2Y8AsgTpgAmY7PhCfg==",
-                "name": "test-object-name",
-            }
+        spec = storage_pb2.WriteObjectSpec(
+            resource={"name": "object", "bucket": "projects/_/buckets/bucket-name"},
+            predefined_acl=storage_pb2.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE,
+            if_generation_not_match=1,
+            if_metageneration_match=2,
+            if_metageneration_not_match=3,
         )
-        environ = create_environ(
-            base_url="http://localhost:8080",
-            content_length=len(data),
-            data=data,
-            content_type="application/json",
-            method="POST",
+        request = storage_pb2.StartResumableWriteRequest(write_object_spec=spec)
+        upload = gcs.holder.DataHolder.init_resumable_grpc(request, bucket.metadata, "")
+        # Verify the annotations inserted by the emulator.
+        annotations = upload.metadata.metadata
+        self.assertGreaterEqual(
+            set(["x_emulator_upload", "x_emulator_no_crc32c", "x_emulator_no_md5"]),
+            set(annotations.keys()),
         )
-        upload = gcs.holder.DataHolder.init_resumable_rest(
-            Request(environ), bucket.metadata
-        )
-        self.assertEqual(upload.metadata.name, "test-object-name")
-        self.assertEqual(upload.metadata.checksums.crc32c, 0)
+        # Clear any annotations created by the emulator
+        upload.metadata.metadata.clear()
         self.assertEqual(
-            upload.metadata.checksums.md5_hash,
-            base64.b64decode("1B2M2Y8AsgTpgAmY7PhCfg=="),
+            upload.metadata,
+            storage_pb2.Object(name="object", bucket="projects/_/buckets/bucket-name"),
+        )
+        predefined_acl = testbench.acl.extract_predefined_acl(upload.request, False, "")
+        self.assertEqual(
+            predefined_acl, storage_pb2.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE
+        )
+        match, not_match = testbench.generation.extract_precondition(
+            upload.request, False, False, ""
+        )
+        self.assertIsNone(match)
+        self.assertEqual(not_match, 1)
+        match, not_match = testbench.generation.extract_precondition(
+            upload.request, True, False, ""
+        )
+        self.assertEqual(match, 2)
+        self.assertEqual(not_match, 3)
+
+    def test_init_object_write_grpc_resumable(self):
+        request = testbench.common.FakeRequest(
+            args={}, data=json.dumps({"name": "bucket-name"})
+        )
+        bucket, _ = gcs.bucket.Bucket.init(request, None)
+        request = storage_pb2.StartResumableWriteRequest(
+            write_object_spec=storage_pb2.WriteObjectSpec(
+                resource={"name": "object", "bucket": "projects/_/buckets/bucket-name"}
+            )
+        )
+        context = unittest.mock.Mock()
+        upload = gcs.holder.DataHolder.init_resumable_grpc(
+            request, bucket.metadata, context
         )
 
-        app = flask.Flask(__name__)
-        with app.test_request_context():
-            status = upload.resumable_status_rest()
-            self.assertEqual(status.status_code, 308)
-            # Simulate a previous chunk upload
-            upload.media = "The quick brown fox jumps over the lazy dog"
-            status = upload.resumable_status_rest()
-            self.assertEqual(status.status_code, 308)
-            self.assertIn("Range", status.headers)
-            self.assertEqual("bytes=0-42", status.headers.get("Range", None))
+        line = b"The quick brown fox jumps over the lazy dog"
+        r1 = storage_pb2.WriteObjectRequest(
+            upload_id=upload.upload_id,
+            write_offset=0,
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=False,
+        )
+        r2 = storage_pb2.WriteObjectRequest(
+            write_offset=len(line),
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=False,
+        )
+        r3 = storage_pb2.WriteObjectRequest(
+            write_offset=2 * len(line),
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=False,
+        )
+        context = unittest.mock.Mock()
+        db = unittest.mock.Mock()
+        db.get_bucket_without_generation = unittest.mock.MagicMock(return_value=bucket)
+        db.get_upload = unittest.mock.MagicMock(return_value=upload)
+        upload, is_resumable = gcs.holder.DataHolder.init_write_object_grpc(
+            db, [r1, r2, r3], context
+        )
+        self.assertIsNotNone(upload)
+        self.assertFalse(upload.complete)
+        self.assertTrue(is_resumable)
+        self.assertEqual(upload.media, b"".join(3 * [line]))
+        self.assertEqual(upload.metadata.name, "object")
+        self.assertEqual(upload.metadata.bucket, "projects/_/buckets/bucket-name")
+
+        r4 = storage_pb2.WriteObjectRequest(
+            upload_id=upload.upload_id,
+            write_offset=3 * len(line),
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=True,
+        )
+        upload, is_resumable = gcs.holder.DataHolder.init_write_object_grpc(
+            db, [r4], context
+        )
+        self.assertIsNotNone(upload)
+        self.assertTrue(upload.complete)
+        self.assertTrue(is_resumable)
+        self.assertEqual(upload.media, b"".join(4 * [line]))
+        self.assertEqual(upload.metadata.name, "object")
+        self.assertEqual(upload.metadata.bucket, "projects/_/buckets/bucket-name")
+
+    def test_init_object_write_grpc_cannot_resume_completed_upload(self):
+        request = testbench.common.FakeRequest(
+            args={}, data=json.dumps({"name": "bucket-name"})
+        )
+        bucket, _ = gcs.bucket.Bucket.init(request, None)
+        request = storage_pb2.StartResumableWriteRequest(
+            write_object_spec=storage_pb2.WriteObjectSpec(
+                resource={"name": "object", "bucket": "projects/_/buckets/bucket-name"}
+            )
+        )
+        context = unittest.mock.Mock()
+        upload = gcs.holder.DataHolder.init_resumable_grpc(
+            request, bucket.metadata, context
+        )
+
+        line = b"The quick brown fox jumps over the lazy dog"
+        r1 = storage_pb2.WriteObjectRequest(
+            upload_id=upload.upload_id,
+            write_offset=0,
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=True,
+        )
+        db = unittest.mock.Mock()
+        db.get_bucket_without_generation = unittest.mock.MagicMock(return_value=bucket)
+        db.get_upload = unittest.mock.MagicMock(return_value=upload)
+
+        context = unittest.mock.Mock()
+        upload, _ = gcs.holder.DataHolder.init_write_object_grpc(db, [r1], context)
+        self.assertIsNotNone(upload)
+        self.assertTrue(upload.complete)
+
+        context = unittest.mock.Mock()
+        context.abort = unittest.mock.MagicMock()
+        upload, _ = gcs.holder.DataHolder.init_write_object_grpc(db, [r1], context)
+        self.assertIsNone(upload)
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.INVALID_ARGUMENT, unittest.mock.ANY
+        )
+
+    def test_init_object_write_grpc_missing_first_message(self):
+        line = b"The quick brown fox jumps over the lazy dog"
+        r1 = storage_pb2.WriteObjectRequest(
+            write_offset=0,
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=True,
+        )
+        db = unittest.mock.Mock()
+        context = unittest.mock.Mock()
+        upload, _ = gcs.holder.DataHolder.init_write_object_grpc(db, [r1], context)
+        self.assertIsNone(upload)
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.INVALID_ARGUMENT, unittest.mock.ANY
+        )
+
+    def test_init_object_write_grpc_missing_checksum_at_invalid_place(self):
+        line = b"The quick brown fox jumps over the lazy dog"
+        r1 = storage_pb2.WriteObjectRequest(
+            write_object_spec=storage_pb2.WriteObjectSpec(
+                resource={"name": "object", "bucket": "projects/_/buckets/bucket-name"},
+            ),
+            write_offset=0,
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=False,
+        )
+        r2 = storage_pb2.WriteObjectRequest(
+            write_offset=len(line),
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            object_checksums=storage_pb2.ObjectChecksums(
+                crc32c=crc32c.crc32c(b"".join(3 * [line]))
+            ),
+            finish_write=False,
+        )
+        r3 = storage_pb2.WriteObjectRequest(
+            write_offset=2 * len(line),
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=True,
+        )
+        db = unittest.mock.Mock()
+        context = unittest.mock.Mock()
+        upload, _ = gcs.holder.DataHolder.init_write_object_grpc(
+            db, [r1, r2, r3], context
+        )
+        self.assertIsNone(upload)
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.INVALID_ARGUMENT, unittest.mock.ANY
+        )
+
+    def test_init_object_write_grpc_missing_checksum_duplicated(self):
+        line = b"The quick brown fox jumps over the lazy dog"
+        r1 = storage_pb2.WriteObjectRequest(
+            write_object_spec=storage_pb2.WriteObjectSpec(
+                resource={"name": "object", "bucket": "projects/_/buckets/bucket-name"},
+            ),
+            write_offset=0,
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            object_checksums=storage_pb2.ObjectChecksums(
+                crc32c=crc32c.crc32c(b"".join(3 * [line]))
+            ),
+            finish_write=False,
+        )
+        r2 = storage_pb2.WriteObjectRequest(
+            write_offset=len(line),
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            finish_write=False,
+        )
+        r3 = storage_pb2.WriteObjectRequest(
+            write_offset=2 * len(line),
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(line)
+            ),
+            object_checksums=storage_pb2.ObjectChecksums(
+                crc32c=crc32c.crc32c(b"".join(3 * [line]))
+            ),
+            finish_write=True,
+        )
+        db = unittest.mock.Mock()
+        context = unittest.mock.Mock()
+        upload, _ = gcs.holder.DataHolder.init_write_object_grpc(
+            db, [r1, r2, r3], context
+        )
+        self.assertIsNone(upload)
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.INVALID_ARGUMENT, unittest.mock.ANY
+        )
+
+    def test_init_object_write_grpc_invalid_checksum(self):
+        line = b"The quick brown fox jumps over the lazy dog"
+        r1 = storage_pb2.WriteObjectRequest(
+            write_object_spec=storage_pb2.WriteObjectSpec(
+                resource={"name": "object", "bucket": "projects/_/buckets/bucket-name"},
+            ),
+            write_offset=0,
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=line, crc32c=crc32c.crc32c(2 * line)
+            ),
+            object_checksums=storage_pb2.ObjectChecksums(
+                crc32c=crc32c.crc32c(b"".join(3 * [line]))
+            ),
+            finish_write=True,
+        )
+        db = unittest.mock.Mock()
+        context = unittest.mock.Mock()
+        upload, _ = gcs.holder.DataHolder.init_write_object_grpc(db, [r1], context)
+        self.assertIsNone(upload)
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.FAILED_PRECONDITION, unittest.mock.ANY
+        )
+
+    def test_init_object_write_grpc_empty(self):
+        db = unittest.mock.Mock()
+        context = unittest.mock.Mock()
+        upload, _ = gcs.holder.DataHolder.init_write_object_grpc(db, [], context)
+        self.assertIsNone(upload)
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.INVALID_ARGUMENT, unittest.mock.ANY
+        )
 
     def test_rewrite_rest(self):
         request = testbench.common.FakeRequest(


### PR DESCRIPTION
Rewrite the support functions (mostly in `holder.py`) for gRPC writes.
They now support resumable uploads, non-resumable uploads, and correctly
report a number of error conditions.

Part of the work for #58 
