### PR TITLE
feat: add support files for packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,1 @@
-git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
-grpcio==1.38.1
-grpcio-tools==1.38.1
-googleapis-common-protos==1.53.0
-protobuf==3.17.3
-flask==2.0.1
-httpbin==0.7.0
-requests-toolbelt==0.9.1
-scalpl==0.4.2
-crc32c==2.2
-gunicorn==20.1.0
-schema==0.7.4
+.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import setuptools
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="googleapis-storage-testbench",
+    version="0.4.0",
+    author="Google LLC",
+    author_email="googleapis-packages@google.com",
+    description="A testbench for Google Cloud Storage client libraries",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/googleapis/storage-testbench",
+    project_urls={
+        "Bug Tracker": "https://github.com/googleapis/storage-testbench/issues",
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache-2.0",
+        "Operating System :: OS Independent",
+    ],
+    package_dir={"": "."},
+    packages=["google/storage/v2", "google/iam/v1", "testbench", "gcs"],
+    python_requires=">=3.6",
+    install_requires=[
+        "grpcio==1.38.1",
+        "grpcio-tools==1.38.1",
+        "googleapis-common-protos==1.53.0",
+        "protobuf==3.17.3",
+        "flask==2.0.1",
+        "httpbin==0.7.0",
+        "requests-toolbelt==0.9.1",
+        "scalpl==0.4.2",
+        "crc32c==2.2",
+        "gunicorn==20.1.0",
+        "schema==0.7.4",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
         "License :: OSI Approved :: Apache-2.0",
         "Operating System :: OS Independent",
     ],
-    package_dir={"": "."},
     packages=["google/storage/v2", "google/iam/v1", "testbench", "gcs"],
     python_requires=">=3.6",
     install_requires=[


### PR DESCRIPTION
The intent is to use this with a github URL from `google-cloud-cpp`, or
from any other repository with similar needs. We do *NOT* anticipate
publishing this to PyPI.

This is my first time creating a Python package. It is likely that I am doing
something wrong.
