### PR TITLE
cleanup: sort import directives

### DIFF
--- a/gcs/bucket.py
+++ b/gcs/bucket.py
@@ -20,12 +20,11 @@ import hashlib
 import json
 import random
 import re
-import scalpl
+
+from google.protobuf import field_mask_pb2, json_format
 
 from google.storage.v2 import storage_pb2
 from google.iam.v1 import policy_pb2
-from google.protobuf import field_mask_pb2, json_format
-
 import testbench
 
 

--- a/gcs/holder.py
+++ b/gcs/holder.py
@@ -14,16 +14,15 @@
 
 """Implement a holder for resumable upload's data and rewrite's data"""
 
-from typing import ClassVar
-import crc32c
 import flask
 import hashlib
 import json
 import types
 
-from google.storage.v2 import storage_pb2
+import crc32c
 from google.protobuf import json_format
 
+from google.storage.v2 import storage_pb2
 import testbench
 
 

--- a/gcs/holder.py
+++ b/gcs/holder.py
@@ -14,12 +14,12 @@
 
 """Implement a holder for resumable upload's data and rewrite's data"""
 
-import flask
 import hashlib
 import json
 import types
 
 import crc32c
+import flask
 from google.protobuf import json_format
 
 from google.storage.v2 import storage_pb2

--- a/gcs/iam.py
+++ b/gcs/iam.py
@@ -16,8 +16,9 @@
 
 import base64
 import binascii
-import flask
 import json
+
+import flask
 
 import testbench
 

--- a/gcs/object.py
+++ b/gcs/object.py
@@ -18,7 +18,6 @@ import base64
 import datetime
 import hashlib
 import json
-import random
 import re
 import socket
 import struct

--- a/gcs/project.py
+++ b/gcs/project.py
@@ -15,11 +15,11 @@
 """Implement a class to simulate projects (service accounts and HMAC keys)."""
 
 import base64
-from functools import wraps
-import flask
 import json
 import random
 import time
+
+import flask
 
 import testbench
 

--- a/testbench/acl.py
+++ b/testbench/acl.py
@@ -17,9 +17,9 @@
 import hashlib
 import os
 
-import testbench
-
 from google.storage.v2 import storage_pb2
+
+import testbench
 
 PROJECT_NUMBER = os.getenv(
     "GOOGLE_CLOUD_CPP_STORAGE_EMULATOR_PROJECT_NUMBER", "123456789"

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -16,21 +16,21 @@
 
 import base64
 from functools import wraps
-import flask
 import json
 import random
 import re
-import scalpl
 import socket
 import struct
 import types
 
-from grpc import StatusCode
+import flask
 from google.protobuf import timestamp_pb2
+from grpc import StatusCode
 from requests_toolbelt import MultipartDecoder
 from requests_toolbelt.multipart.decoder import ImproperBodyPartContentException
-from google.storage.v2 import storage_pb2
+import scalpl
 
+from google.storage.v2 import storage_pb2
 import testbench
 
 re_remove_index = re.compile(r"\[\d+\]+|^[0-9]+")

--- a/testbench/error.py
+++ b/testbench/error.py
@@ -16,6 +16,7 @@
 
 import json
 import traceback
+
 import flask
 import grpc
 from werkzeug.exceptions import HTTPException

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import crc32c
-import grpc
-import testbench
 from concurrent import futures
+
+import crc32c
 from google.storage.v2 import storage_pb2, storage_pb2_grpc
+import grpc
 
 import gcs
+import testbench
 
 
 class StorageServicer(storage_pb2_grpc.StorageServicer):

--- a/testbench/handle_gzip.py
+++ b/testbench/handle_gzip.py
@@ -14,6 +14,7 @@
 
 import io
 import gzip
+
 from werkzeug.wrappers import Request
 
 

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -13,18 +13,16 @@
 # limitations under the License.
 
 import argparse
-from testbench import grpc_server
 import flask
 import httpbin
 import json
 import logging
-from functools import wraps
 from werkzeug import serving
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
-from google.storage.v2 import storage_pb2
 from google.protobuf import json_format
 
+from google.storage.v2 import storage_pb2
 import gcs as gcs_type
 import testbench
 

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import argparse
-import flask
 import httpbin
 import json
 import logging
+
+import flask
+from google.protobuf import json_format
 from werkzeug import serving
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
-
-from google.protobuf import json_format
 
 from google.storage.v2 import storage_pb2
 import gcs as gcs_type

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -19,7 +19,6 @@
 import json
 import unittest
 
-from google.storage.v2 import storage_pb2
 from google.protobuf import json_format
 
 import gcs

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -18,10 +18,10 @@
 
 import base64
 import hashlib
-import flask
 import json
 import unittest
 
+import flask
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
 from google.storage.v2 import storage_pb2

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -16,11 +16,12 @@
 
 """Test for error handling helpers."""
 
-from testbench import error
-
-import grpc
 import unittest
 from unittest.mock import ANY, Mock
+
+import grpc
+
+from testbench import error
 
 
 class TestError(unittest.TestCase):

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -17,8 +17,8 @@
 """Unit tests for testbench.generation."""
 
 import unittest
-from google.storage.v2 import storage_pb2
 
+from google.storage.v2 import storage_pb2
 import testbench.generation
 
 

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -16,14 +16,15 @@
 
 """Unit test for testbench.grpc."""
 
-import crc32c
 import json
 import unittest
 import unittest.mock
+
+import crc32c
 import grpc
-from google.storage.v2 import storage_pb2, storage_pb2_grpc
 
 import gcs
+from google.storage.v2 import storage_pb2, storage_pb2_grpc
 import testbench
 
 

--- a/tests/test_handle_gzip.py
+++ b/tests/test_handle_gzip.py
@@ -18,8 +18,8 @@
 
 import gzip
 import unittest
+
 from werkzeug.test import create_environ
-from werkzeug.wrappers import Request
 
 import testbench
 

--- a/tests/test_holder.py
+++ b/tests/test_holder.py
@@ -18,12 +18,12 @@
 
 import base64
 import hashlib
-import flask
 import json
 import unittest
 import unittest.mock
 
 import crc32c
+import flask
 import grpc
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request

--- a/tests/test_holder.py
+++ b/tests/test_holder.py
@@ -16,19 +16,20 @@
 
 """Tests for the Object class (see gcs/object.py)."""
 
-import crc32c
 import base64
 import hashlib
 import flask
 import json
 import unittest
 import unittest.mock
-from google.storage.v2 import storage_pb2
+
+import crc32c
 import grpc
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
 
 import gcs
+from google.storage.v2 import storage_pb2
 import testbench
 
 

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -24,9 +24,9 @@ import unittest.mock
 
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
-from google.storage.v2 import storage_pb2
 
 import gcs
+from google.storage.v2 import storage_pb2
 import testbench
 from tests.format_multipart_upload import format_multipart_upload
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -18,8 +18,9 @@
 
 import json
 import unittest
-import testbench
+
 import gcs.project
+import testbench
 
 
 class TestProject(unittest.TestCase):

--- a/tests/test_testbench_bucket.py
+++ b/tests/test_testbench_bucket.py
@@ -18,9 +18,9 @@
 
 import json
 import os
-from testbench import rest_server
-from testbench.common import rest_adjust
 import unittest
+
+from testbench import rest_server
 
 
 class TestTestbenchBucket(unittest.TestCase):

--- a/tests/test_testbench_continue_after_fault_injection.py
+++ b/tests/test_testbench_continue_after_fault_injection.py
@@ -18,12 +18,11 @@
 
 import json
 import re
-import requests
 import subprocess
 import time
 import unittest
 
-from requests.models import iter_slices
+import requests
 
 
 class TestTestbenchContinueAfterFaultInjection(unittest.TestCase):

--- a/tests/test_testbench_object_metadata.py
+++ b/tests/test_testbench_object_metadata.py
@@ -19,7 +19,6 @@
 import json
 import os
 import unittest
-from werkzeug.test import create_environ
 
 import gcs
 from testbench import rest_server

--- a/tests/test_testbench_object_special.py
+++ b/tests/test_testbench_object_special.py
@@ -19,7 +19,6 @@
 import json
 import os
 import unittest
-from werkzeug.test import create_environ
 
 from testbench import rest_server
 

--- a/tests/test_testbench_object_upload.py
+++ b/tests/test_testbench_object_upload.py
@@ -20,7 +20,6 @@ import json
 import os
 import re
 import unittest
-from werkzeug.test import create_environ
 
 from testbench import rest_server
 from tests.format_multipart_upload import format_multipart_upload

--- a/tests/test_testbench_object_xml.py
+++ b/tests/test_testbench_object_xml.py
@@ -19,7 +19,6 @@
 import json
 import os
 import unittest
-from werkzeug.test import create_environ
 
 from testbench import rest_server
 

--- a/tests/test_testbench_startup.py
+++ b/tests/test_testbench_startup.py
@@ -18,11 +18,13 @@
 
 import json
 import re
-import requests
 import subprocess
 import time
 import unittest
+
 import grpc
+import requests
+
 from google.storage.v2 import storage_pb2, storage_pb2_grpc
 
 


### PR DESCRIPTION
The recommended order seems to be standard library modules, then
packages, then local modules.
