### PR TITLE
ci: speedup unit tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,19 +22,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Test with pytest
-        env:
-          PYTHONPATH: "."
-        run: |
-          pytest
-      - name: Generate coverage report
+          pip install -e .
+      - name: Run Unit Tests with Coverage
         env:
           PYTHONPATH: "."
         run: |
           pytest --cov=./ --cov-report=xml
+      # Upload code coverage reports only for 3.9
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
+        if: ${{ matrix.python-version == "3.9" }}
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,10 +28,8 @@ jobs:
           PYTHONPATH: "."
         run: |
           pytest --cov=./ --cov-report=xml
-      # Upload code coverage reports only for 3.9
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
-        if: ${{ matrix.python-version == "3.9" }}
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true


### PR DESCRIPTION
We were running the unit (and integration) tests twice, once without
code coverage and once with coverage. That is duplicating work.