### PR TITLE
fix: automatically created bucket and gRPC

### DIFF
--- a/testbench/database.py
+++ b/testbench/database.py
@@ -102,7 +102,7 @@ class Database:
         del self.objects[bucket.metadata.name]
         del self.live_generations[bucket.metadata.name]
 
-    def insert_test_bucket(self, context):
+    def insert_test_bucket(self):
         """Automatically create a bucket if needed.
 
         Many of the integration tests for `google-cloud-cpp` assume a
@@ -113,12 +113,12 @@ class Database:
         bucket_name = os.environ.get("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
         if bucket_name is None:
             return
-        if self.buckets.get(self.__bucket_key(bucket_name, context)) is None:
+        if self.buckets.get(self.__bucket_key(bucket_name, None)) is None:
             request = testbench.common.FakeRequest(
                 args={}, data=json.dumps({"name": bucket_name})
             )
-            bucket_test, _ = gcs.bucket.Bucket.init(request, context)
-            self.insert_bucket(request, bucket_test, context)
+            bucket_test, _ = gcs.bucket.Bucket.init(request, None)
+            self.insert_bucket(request, bucket_test, None)
             bucket_test.metadata.metageneration = 4
             bucket_test.metadata.versioning.enabled = True
 

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -51,7 +51,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         return self.db.get_bucket_without_generation(bucket_name, context).metadata
 
     def WriteObject(self, request_iterator, context):
-        self.db.insert_test_bucket(context)
+        self.db.insert_test_bucket()
         upload, is_resumable = gcs.holder.DataHolder.init_write_object_grpc(
             self.db, request_iterator, context
         )

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -57,7 +57,7 @@ def raise_error():
 
 
 def xml_put_object(bucket_name, object_name):
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
     bucket = db.get_bucket_without_generation(bucket_name, None).metadata
     blob, fake_request = gcs_type.object.Object.init_xml(
         flask.request, bucket, object_name
@@ -162,7 +162,7 @@ gcs.register_error_handler(Exception, testbench.error.RestException.handler)
 @gcs.route("/b", methods=["GET"])
 @retry_test(method="storage.buckets.list")
 def bucket_list():
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
     project = flask.request.args.get("project")
     projection = flask.request.args.get("projection", "noAcl")
     fields = flask.request.args.get("fields", None)
@@ -178,7 +178,7 @@ def bucket_list():
 @gcs.route("/b", methods=["POST"])
 @retry_test(method="storage.buckets.insert")
 def bucket_insert():
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
     bucket, projection = gcs_type.bucket.Bucket.init(flask.request, None)
     fields = flask.request.args.get("fields", None)
     db.insert_bucket(flask.request, bucket, None)
@@ -188,8 +188,8 @@ def bucket_insert():
 @gcs.route("/b/<bucket_name>")
 @retry_test(method="storage.buckets.get")
 def bucket_get(bucket_name):
-    db.insert_test_bucket(None)
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
+    db.insert_test_bucket()
     bucket = db.get_bucket(flask.request, bucket_name, None)
     projection = testbench.common.extract_projection(flask.request, "noAcl", None)
     fields = flask.request.args.get("fields", None)
@@ -199,7 +199,7 @@ def bucket_get(bucket_name):
 @gcs.route("/b/<bucket_name>", methods=["PUT"])
 @retry_test(method="storage.buckets.update")
 def bucket_update(bucket_name):
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
     bucket = db.get_bucket(flask.request, bucket_name, None)
     bucket.update(flask.request, None)
     projection = testbench.common.extract_projection(flask.request, "full", None)
@@ -392,7 +392,7 @@ def bucket_notification_delete(bucket_name, notification_id):
 @gcs.route("/b/<bucket_name>/iam")
 @retry_test(method="storage.buckets.getIamPolicy")
 def bucket_get_iam_policy(bucket_name):
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
     bucket = db.get_bucket(flask.request, bucket_name, None)
     response = json_format.MessageToDict(bucket.iam_policy)
     response["kind"] = "storage#policy"
@@ -402,7 +402,7 @@ def bucket_get_iam_policy(bucket_name):
 @gcs.route("/b/<bucket_name>/iam", methods=["PUT"])
 @retry_test(method="storage.buckets.setIamPolicy")
 def bucket_set_iam_policy(bucket_name):
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
     bucket = db.get_bucket(flask.request, bucket_name, None)
     bucket.set_iam_policy(flask.request, None)
     response = json_format.MessageToDict(bucket.iam_policy)
@@ -433,7 +433,7 @@ def bucket_lock_retention_policy(bucket_name):
 @gcs.route("/b/<bucket_name>/o")
 @retry_test(method="storage.objects.list")
 def object_list(bucket_name):
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
     items, prefixes = db.list_object(flask.request, bucket_name, None)
     response = {
         "kind": "storage#objects",
@@ -545,7 +545,7 @@ def objects_compose(bucket_name, object_name):
 )
 @retry_test(method="storage.objects.copy")
 def objects_copy(src_bucket_name, src_object_name, dst_bucket_name, dst_object_name):
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
     dst_bucket = db.get_bucket_without_generation(dst_bucket_name, None).metadata
     src_object = db.get_object(
         flask.request, src_bucket_name, src_object_name, True, None
@@ -579,7 +579,7 @@ def objects_copy(src_bucket_name, src_object_name, dst_bucket_name, dst_object_n
 )
 @retry_test(method="storage.objects.rewrite")
 def objects_rewrite(src_bucket_name, src_object_name, dst_bucket_name, dst_object_name):
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
     token, rewrite = flask.request.args.get("rewriteToken"), None
     src_object = None
     if token is None:
@@ -728,7 +728,7 @@ upload.register_error_handler(Exception, testbench.error.RestException.handler)
 @upload.route("/b/<bucket_name>/o", methods=["POST"])
 @retry_test(method="storage.objects.insert")
 def object_insert(bucket_name):
-    db.insert_test_bucket(None)
+    db.insert_test_bucket()
     bucket = db.get_bucket_without_generation(bucket_name, None).metadata
     upload_type = flask.request.args.get("uploadType")
     if upload_type is None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -94,12 +94,12 @@ class TestDatabaseBucket(unittest.TestCase):
             data=json.dumps({}),
         )
         os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
-        database.insert_test_bucket(None)
+        database.insert_test_bucket()
         names = {b.metadata.name for b in database.list_bucket(request, "", None)}
         self.assertEqual(names, set())
 
         os.environ["GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME"] = "test-bucket-1"
-        database.insert_test_bucket(None)
+        database.insert_test_bucket()
         get_result = database.get_bucket(request, "test-bucket-1", None)
         self.assertEqual(get_result.metadata.bucket_id, "test-bucket-1")
 


### PR DESCRIPTION
Using the original request context is a bad idea. First, because
we really are using the REST code path, and second because
we really do not want to send errors back to the application
if this fails.
