### PR TITLE
fix: use locks when accessing the database

### DIFF
--- a/testbench/common.py
+++ b/testbench/common.py
@@ -456,7 +456,7 @@ def handle_retry_test_instruction(database, request, method):
         # Upload failures should allow to not complete after certain bytes
         upload_id = request.args.get("upload_id", None)
         if upload_id is not None:
-            upload = database.uploads.get(upload_id)
+            upload = database.get_upload(upload_id, None)
             if upload is not None and len(upload.media) >= after_bytes:
                 database.dequeue_next_instruction(test_id, method)
                 testbench.error.generic(

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -15,6 +15,7 @@
 import collections
 import json
 import os
+import threading
 import uuid
 
 import gcs
@@ -32,13 +33,20 @@ class Database:
         retry_tests,
         supported_methods,
     ):
-        self.buckets = buckets
-        self.objects = objects
-        self.live_generations = live_generations
-        self.uploads = uploads
-        self.rewrites = rewrites
-        self.retry_tests = retry_tests
-        self.supported_methods = supported_methods
+        self._resources_lock = threading.RLock()
+        self._buckets = buckets
+        self._objects = objects
+        self._live_generations = live_generations
+
+        self._uploads_lock = threading.RLock()
+        self._uploads = uploads
+
+        self._rewrites_lock = threading.RLock()
+        self._rewrites = rewrites
+
+        self._retry_tests_lock = threading.RLock()
+        self._retry_tests = retry_tests
+        self._supported_methods = supported_methods
 
     @classmethod
     def init(cls):
@@ -46,16 +54,20 @@ class Database:
 
     def clear(self):
         """Clear all data except for the supported method list."""
-        self.buckets = {}
-        self.objects = {}
-        self.live_generations = {}
-        self.uploads = {}
-        self.rewrites = {}
-        self.retry_tests = {}
+        with self._resources_lock:
+            self._buckets = {}
+            self._objects = {}
+            self._live_generations = {}
+        with self._uploads_lock:
+            self._uploads = {}
+        with self._rewrites_lock:
+            self._rewrites = {}
+        with self._retry_tests_lock:
+            self._retry_tests = {}
         # The list of supported methods for `retry_test` is defined via flask
         # decorators, it should remain unchanged after the test or application
         # is initialized. Arguably this means it should be in a global variable.
-        #   TODO(#27) - maybe `self.supported_methods` should be a global
+        #   TODO(#27) - maybe `self._supported_methods` should be a global
 
     # === BUCKET === #
 
@@ -74,33 +86,38 @@ class Database:
         return testbench.common.bucket_name_to_proto(bucket_name)
 
     def get_bucket_without_generation(self, bucket_name, context):
-        bucket = self.buckets.get(self.__bucket_key(bucket_name, context))
-        if bucket is None:
-            testbench.error.notfound("Bucket %s" % bucket_name, context)
-        return bucket
+        with self._resources_lock:
+            bucket = self._buckets.get(self.__bucket_key(bucket_name, context))
+            if bucket is None:
+                testbench.error.notfound("Bucket %s" % bucket_name, context)
+            return bucket
 
     def insert_bucket(self, request, bucket, context):
-        self.buckets[bucket.metadata.name] = bucket
-        self.objects[bucket.metadata.name] = {}
-        self.live_generations[bucket.metadata.name] = {}
+        with self._resources_lock:
+            self._buckets[bucket.metadata.name] = bucket
+            self._objects[bucket.metadata.name] = {}
+            self._live_generations[bucket.metadata.name] = {}
 
     def get_bucket(self, request, bucket_name, context):
-        bucket = self.get_bucket_without_generation(bucket_name, context)
-        self.__check_bucket_metageneration(request, bucket, context)
-        return bucket
+        with self._resources_lock:
+            bucket = self.get_bucket_without_generation(bucket_name, context)
+            self.__check_bucket_metageneration(request, bucket, context)
+            return bucket
 
     def list_bucket(self, request, project_id, context):
-        if project_id is None or project_id.endswith("-"):
-            testbench.error.invalid("Project id %s" % project_id, context)
-        return self.buckets.values()
+        with self._resources_lock:
+            if project_id is None or project_id.endswith("-"):
+                testbench.error.invalid("Project id %s" % project_id, context)
+            return self._buckets.values()
 
     def delete_bucket(self, request, bucket_name, context):
-        bucket = self.get_bucket(request, bucket_name, context)
-        if len(self.live_generations[bucket.metadata.name]) > 0:
-            testbench.error.invalid("Deleting non-empty bucket", context)
-        del self.buckets[bucket.metadata.name]
-        del self.objects[bucket.metadata.name]
-        del self.live_generations[bucket.metadata.name]
+        with self._resources_lock:
+            bucket = self.get_bucket(request, bucket_name, context)
+            if len(self._live_generations[bucket.metadata.name]) > 0:
+                testbench.error.invalid("Deleting non-empty bucket", context)
+            del self._buckets[bucket.metadata.name]
+            del self._objects[bucket.metadata.name]
+            del self._live_generations[bucket.metadata.name]
 
     def insert_test_bucket(self):
         """Automatically create a bucket if needed.
@@ -113,19 +130,20 @@ class Database:
         bucket_name = os.environ.get("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
         if bucket_name is None:
             return
-        if self.buckets.get(self.__bucket_key(bucket_name, None)) is None:
-            request = testbench.common.FakeRequest(
-                args={}, data=json.dumps({"name": bucket_name})
-            )
-            bucket_test, _ = gcs.bucket.Bucket.init(request, None)
-            self.insert_bucket(request, bucket_test, None)
-            bucket_test.metadata.metageneration = 4
-            bucket_test.metadata.versioning.enabled = True
+        with self._resources_lock:
+            if self._buckets.get(self.__bucket_key(bucket_name, None)) is None:
+                request = testbench.common.FakeRequest(
+                    args={}, data=json.dumps({"name": bucket_name})
+                )
+                bucket_test, _ = gcs.bucket.Bucket.init(request, None)
+                self.insert_bucket(request, bucket_test, None)
+                bucket_test.metadata.metageneration = 4
+                bucket_test.metadata.versioning.enabled = True
 
     # === OBJECT === #
 
     def __get_bucket_for_object(self, bucket_name, context):
-        bucket = self.objects.get(self.__bucket_key(bucket_name, context))
+        bucket = self._objects.get(self.__bucket_key(bucket_name, context))
         if bucket is None:
             testbench.error.notfound("Bucket %s" % bucket_name, context)
         return bucket
@@ -153,48 +171,52 @@ class Database:
 
     def __get_live_generation(self, bucket_name, object_name, context):
         bucket_key = self.__bucket_key(bucket_name, context)
-        return self.live_generations[bucket_key].get(object_name)
+        return self._live_generations[bucket_key].get(object_name)
 
     def __set_live_generation(self, bucket_name, object_name, generation, context):
         bucket_key = self.__bucket_key(bucket_name, context)
-        self.live_generations[bucket_key][object_name] = generation
+        self._live_generations[bucket_key][object_name] = generation
 
     def __del_live_generation(self, bucket_name, object_name, context):
         bucket_key = self.__bucket_key(bucket_name, context)
-        self.live_generations[bucket_key].pop(object_name, None)
+        self._live_generations[bucket_key].pop(object_name, None)
 
     def list_object(self, request, bucket_name, context):
-        bucket = self.__get_bucket_for_object(bucket_name, context)
-        (
-            delimiter,
-            prefix,
-            versions,
-            start_offset,
-            end_offset,
-            include_trailing_delimiter,
-        ) = self.__extract_list_object_request(request, context)
-        items = []
-        prefixes = set()
-        for obj in bucket.values():
-            generation = obj.metadata.generation
-            name = obj.metadata.name
-            if not versions and generation != self.__get_live_generation(
-                bucket_name, name, context
-            ):
-                continue
-            if name.find(prefix) != 0:
-                continue
-            if name < start_offset:
-                continue
-            if end_offset and name >= end_offset:
-                continue
-            delimiter_index = name.find(delimiter, len(prefix))
-            if delimiter != "" and delimiter_index > 0:
-                prefixes.add(name[: delimiter_index + 1])
-                if delimiter_index < len(name) - 1 or not include_trailing_delimiter:
+        with self._resources_lock:
+            bucket = self.__get_bucket_for_object(bucket_name, context)
+            (
+                delimiter,
+                prefix,
+                versions,
+                start_offset,
+                end_offset,
+                include_trailing_delimiter,
+            ) = self.__extract_list_object_request(request, context)
+            items = []
+            prefixes = set()
+            for obj in bucket.values():
+                generation = obj.metadata.generation
+                name = obj.metadata.name
+                if not versions and generation != self.__get_live_generation(
+                    bucket_name, name, context
+                ):
                     continue
-            items.append(obj.metadata)
-        return items, list(prefixes)
+                if name.find(prefix) != 0:
+                    continue
+                if name < start_offset:
+                    continue
+                if end_offset and name >= end_offset:
+                    continue
+                delimiter_index = name.find(delimiter, len(prefix))
+                if delimiter != "" and delimiter_index > 0:
+                    prefixes.add(name[: delimiter_index + 1])
+                    if (
+                        delimiter_index < len(name) - 1
+                        or not include_trailing_delimiter
+                    ):
+                        continue
+                items.append(obj.metadata)
+            return items, list(prefixes)
 
     def _check_object_generation(
         self, request, bucket_name, object_name, is_source, context
@@ -224,69 +246,83 @@ class Database:
         return blob, generation, bucket
 
     def get_object(self, request, bucket_name, object_name, is_source, context):
-        blob, generation, _ = self._check_object_generation(
-            request, bucket_name, object_name, is_source, context
-        )
-        if blob is None:
-            if generation == 0:
-                testbench.error.notfound(
-                    "Live version of object %s" % object_name, context
-                )
-            else:
-                testbench.error.notfound(
-                    "Object %s with generation %d" % (object_name, generation), context
-                )
-        return blob
+        with self._resources_lock:
+            blob, generation, _ = self._check_object_generation(
+                request, bucket_name, object_name, is_source, context
+            )
+            if blob is None:
+                if generation == 0:
+                    testbench.error.notfound(
+                        "Live version of object %s" % object_name, context
+                    )
+                else:
+                    testbench.error.notfound(
+                        "Object %s with generation %d" % (object_name, generation),
+                        context,
+                    )
+            return blob
 
     def insert_object(self, request, bucket_name, blob, context):
-        name = blob.metadata.name
-        _, _, bucket = self._check_object_generation(
-            request, bucket_name, name, False, context
-        )
-        generation = blob.metadata.generation
-        bucket["%s#%d" % (name, generation)] = blob
-        self.__set_live_generation(bucket_name, name, generation, context)
+        with self._resources_lock:
+            name = blob.metadata.name
+            _, _, bucket = self._check_object_generation(
+                request, bucket_name, name, False, context
+            )
+            generation = blob.metadata.generation
+            bucket["%s#%d" % (name, generation)] = blob
+            self.__set_live_generation(bucket_name, name, generation, context)
 
     def delete_object(self, request, bucket_name, object_name, context):
-        _ = self.get_object(request, bucket_name, object_name, False, context)
-        generation = testbench.generation.extract_generation(request, False, context)
-        live_generation = self.__get_live_generation(bucket_name, object_name, context)
-        if generation == 0 or live_generation == generation:
-            self.__del_live_generation(bucket_name, object_name, context)
-        if generation != 0:
-            self.objects[self.__bucket_key(bucket_name, context)].pop(
-                "%s#%d" % (object_name, generation), None
+        with self._resources_lock:
+            _ = self.get_object(request, bucket_name, object_name, False, context)
+            generation = testbench.generation.extract_generation(
+                request, False, context
             )
+            live_generation = self.__get_live_generation(
+                bucket_name, object_name, context
+            )
+            if generation == 0 or live_generation == generation:
+                self.__del_live_generation(bucket_name, object_name, context)
+            if generation != 0:
+                self._objects[self.__bucket_key(bucket_name, context)].pop(
+                    "%s#%d" % (object_name, generation), None
+                )
 
     # === UPLOAD === #
 
     def get_upload(self, upload_id, context):
-        upload = self.uploads.get(upload_id)
-        if upload is None:
-            testbench.error.notfound("Upload %s" % upload_id, context)
-        return upload
+        with self._uploads_lock:
+            upload = self._uploads.get(upload_id)
+            if upload is None:
+                testbench.error.notfound("Upload %s" % upload_id, context)
+            return upload
 
     def insert_upload(self, upload):
-        self.uploads[upload.upload_id] = upload
+        with self._uploads_lock:
+            self._uploads[upload.upload_id] = upload
 
     def delete_upload(self, upload_id, context):
-        self.get_upload(upload_id, context)
-        del self.uploads[upload_id]
+        with self._uploads_lock:
+            self.get_upload(upload_id, context)
+            del self._uploads[upload_id]
 
     # === REWRITE === #
 
     def get_rewrite(self, token, context):
-        rewrite = self.rewrites.get(token)
-        if rewrite is None:
-            testbench.error.notfound("Rewrite %s" % token, context)
-        return rewrite
+        with self._rewrites_lock:
+            rewrite = self._rewrites.get(token)
+            if rewrite is None:
+                testbench.error.notfound("Rewrite %s" % token, context)
+            return rewrite
 
     def insert_rewrite(self, rewrite):
-        self.rewrites[rewrite.token] = rewrite
+        with self._rewrites_lock:
+            self._rewrites[rewrite.token] = rewrite
 
     def delete_rewrite(self, token, context):
-        self.get_rewrite(token, context)
-        del self.rewrites[token]
+        with self._rewrites_lock:
+            self.get_rewrite(token, context)
+            del self._rewrites[token]
 
     # ==== RETRY_TESTS ==== #
 
@@ -300,14 +336,20 @@ class Database:
             "completed": retry_test["completed"],
         }
 
+    def supported_methods(self):
+        with self._retry_tests_lock:
+            return self._supported_methods
+
     def insert_supported_methods(self, methods):
-        self.supported_methods.extend(methods)
+        with self._retry_tests_lock:
+            self._supported_methods.extend(methods)
 
     def get_retry_test(self, retry_test_id):
-        retry_test = self.retry_tests.get(retry_test_id)
-        if retry_test is None:
-            testbench.error.notfound("Retry Test %s" % retry_test_id, context=None)
-        return self.__to_serializeable_retry_test(retry_test)
+        with self._retry_tests_lock:
+            retry_test = self._retry_tests.get(retry_test_id)
+            if retry_test is None:
+                testbench.error.notfound("Retry Test %s" % retry_test_id, context=None)
+            return self.__to_serializeable_retry_test(retry_test)
 
     def __validate_injected_failure_description(self, failure):
         for expr in [
@@ -321,7 +363,7 @@ class Database:
 
     def __validate_instructions(self, instructions):
         for method, failures in instructions.items():
-            if method not in self.supported_methods:
+            if method not in self._supported_methods:
                 testbench.error.invalid(
                     "The requested method <%s> for fault injection" % method, None
                 )
@@ -329,49 +371,59 @@ class Database:
                 self.__validate_injected_failure_description(failure)
 
     def insert_retry_test(self, instructions):
-        self.__validate_instructions(instructions)
-        retry_test_id = uuid.uuid4().hex
-        self.retry_tests[retry_test_id] = {
-            "id": retry_test_id,
-            "instructions": {
-                key: collections.deque(value) for key, value in instructions.items()
-            },
-            "completed": False,
-        }
-        return self.__to_serializeable_retry_test(self.retry_tests[retry_test_id])
+        with self._retry_tests_lock:
+            self.__validate_instructions(instructions)
+            retry_test_id = uuid.uuid4().hex
+            self._retry_tests[retry_test_id] = {
+                "id": retry_test_id,
+                "instructions": {
+                    key: collections.deque(value) for key, value in instructions.items()
+                },
+                "completed": False,
+            }
+            return self.__to_serializeable_retry_test(self._retry_tests[retry_test_id])
 
     def has_instructions_retry_test(self, retry_test_id, method):
-        self.get_retry_test(retry_test_id)
-        if len(self.retry_tests[retry_test_id]["instructions"].get(method, [])) > 0:
-            return True
-        return False
+        with self._retry_tests_lock:
+            self.get_retry_test(retry_test_id)
+            if (
+                len(self._retry_tests[retry_test_id]["instructions"].get(method, []))
+                > 0
+            ):
+                return True
+            return False
 
     def peek_next_instruction(self, retry_test_id, method):
-        self.get_retry_test(retry_test_id)
-        if self.retry_tests[retry_test_id]["instructions"] and self.retry_tests[
-            retry_test_id
-        ]["instructions"].get(method, None):
-            return self.retry_tests[retry_test_id]["instructions"][method][0]
-        else:
-            return None
+        with self._retry_tests_lock:
+            self.get_retry_test(retry_test_id)
+            if self._retry_tests[retry_test_id]["instructions"] and self._retry_tests[
+                retry_test_id
+            ]["instructions"].get(method, None):
+                return self._retry_tests[retry_test_id]["instructions"][method][0]
+            else:
+                return None
 
     def dequeue_next_instruction(self, retry_test_id, method):
-        self.get_retry_test(retry_test_id)
-        next_instruction = self.retry_tests[retry_test_id]["instructions"][
-            method
-        ].popleft()
-        instructions_left = 0
-        for key, value in self.retry_tests[retry_test_id]["instructions"].items():
-            instructions_left += len(value)
-        if instructions_left == 0:
-            self.retry_tests[retry_test_id]["completed"] = True
-        return next_instruction
+        with self._retry_tests_lock:
+            self.get_retry_test(retry_test_id)
+            next_instruction = self._retry_tests[retry_test_id]["instructions"][
+                method
+            ].popleft()
+            instructions_left = 0
+            for key, value in self._retry_tests[retry_test_id]["instructions"].items():
+                instructions_left += len(value)
+            if instructions_left == 0:
+                self._retry_tests[retry_test_id]["completed"] = True
+            return next_instruction
 
     def list_retry_tests(self):
-        return [
-            self.__to_serializeable_retry_test(x) for x in self.retry_tests.values()
-        ]
+        with self._retry_tests_lock:
+            return [
+                self.__to_serializeable_retry_test(x)
+                for x in self._retry_tests.values()
+            ]
 
     def delete_retry_test(self, retry_test_id):
-        self.get_retry_test(retry_test_id)
-        del self.retry_tests[retry_test_id]
+        with self._retry_tests_lock:
+            self.get_retry_test(retry_test_id)
+            del self._retry_tests[retry_test_id]

--- a/tests/test_testbench_retry.py
+++ b/tests/test_testbench_retry.py
@@ -99,12 +99,12 @@ class TestTestbenchRetry(unittest.TestCase):
             "object_acl": OBJECT_ACL_OPERATIONS,
             "project": PROJECT_OPERATIONS,
         }
-        all = set(rest_server.db.supported_methods)
+        all = set(rest_server.db.supported_methods())
         for name, operations in groups.items():
-            self.assertEqual(all, all | operations)
+            self.assertEqual(all, all | operations, msg=name)
 
     def test_retry_test_crud(self):
-        self.assertIn("storage.buckets.list", rest_server.db.supported_methods)
+        self.assertIn("storage.buckets.list", rest_server.db.supported_methods())
         response = self.client.post(
             "/retry_test",
             data=json.dumps({"instructions": {"storage.buckets.list": ["return-429"]}}),


### PR DESCRIPTION
The database object is a global, shared by many threads. While we could
get away without synchronization (because there is no I/O in it to cause
a thread switch), we shouldn't.

Also renamed all the database fields to ensure they are always accessed
via a method that has the right locking. This is where near 100% code
coverage comes handy.

