### PR TITLE
fix: add retention_policy.effective_time when locking a policy

### DIFF
--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -426,7 +426,9 @@ def bucket_test_iam_permissions(bucket_name):
 def bucket_lock_retention_policy(bucket_name):
     bucket = db.get_bucket(flask.request, bucket_name, None)
     bucket.metadata.retention_policy.is_locked = True
-    bucket.metadata.retention_policy.effective_time.FromDatetime(datetime.datetime.now())
+    bucket.metadata.retention_policy.effective_time.FromDatetime(
+        datetime.datetime.now()
+    )
     return bucket.rest()
 
 

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import datetime
 import httpbin
 import json
 import logging
@@ -425,6 +426,7 @@ def bucket_test_iam_permissions(bucket_name):
 def bucket_lock_retention_policy(bucket_name):
     bucket = db.get_bucket(flask.request, bucket_name, None)
     bucket.metadata.retention_policy.is_locked = True
+    bucket.metadata.retention_policy.effective_time.FromDatetime(datetime.datetime.now())
     return bucket.rest()
 
 


### PR DESCRIPTION
Fixes #116 for the Go conformance tests, which use the lock method and need an effective time to parse. 