### PR TITLE
fix: cleanup filter_response_rest and nested_keys

### DIFF
--- a/testbench/common.py
+++ b/testbench/common.py
@@ -249,7 +249,9 @@ def filter_response_rest(response, projection, fields):
         if fields is not None:
             delete = True
             for field in fields:
-                if field != "" and (simplfied_key.startswith(field) or field.startswith(simplfied_key)):
+                if field != "" and (
+                    simplfied_key.startswith(field) or field.startswith(simplfied_key)
+                ):
                     print(simplfied_key)
                     delete = False
                     break

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -238,7 +238,6 @@ def parse_fields(fields):
 def filter_response_rest(response, projection, fields):
     if fields is not None:
         fields = parse_fields(fields)
-    print(fields)
     keys_to_delete = set()
     if projection == "noAcl":
         keys_to_delete.add("owner")
@@ -252,15 +251,12 @@ def filter_response_rest(response, projection, fields):
                 if field != "" and (
                     simplfied_key.startswith(field) or field.startswith(simplfied_key)
                 ):
-                    print(simplfied_key)
                     delete = False
                     break
             if delete:
                 keys_to_delete.add(key)
 
     proxy = scalpl.Cut(response)
-    print(proxy)
-    print(keys_to_delete)
     for key in keys_to_delete:
         if proxy.get(key) is not None:
             del proxy[key]

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -185,8 +185,7 @@ def nested_key(data):
                     keys.extend(["[%d].%s" % (i, item) for item in result])
                 elif isinstance(data[i], list):
                     keys.extend(["[%d]%s" % (i, item) for item in result])
-            elif result == "":
-                keys.append("[%d]" % i)
+            keys.append("[%d]" % i)
         return keys
     elif isinstance(data, dict):
         keys = []
@@ -197,11 +196,10 @@ def nested_key(data):
                     keys.extend(["%s.%s" % (key, item) for item in result])
                 elif isinstance(value, list):
                     keys.extend(["%s%s" % (key, item) for item in result])
-            elif result == "":
-                keys.append("%s" % key)
+            keys.append("%s" % key)
         return keys
     else:
-        return ""
+        return []
 
 
 def parse_fields(fields):
@@ -240,39 +238,21 @@ def parse_fields(fields):
 def filter_response_rest(response, projection, fields):
     if fields is not None:
         fields = parse_fields(fields)
-    deleted_keys = set()
+    keys_to_delete = set()
+    if projection == 'noAcl':
+        keys_to_delete.add("owner")
+        keys_to_delete.add("acl")
+        keys_to_delete.add("defaultObjectAcl")
     for key in nested_key(response):
-        simplfied_key = remove_index(key)
-        maybe_delete = True
-        if projection == "noAcl":
-            maybe_delete = False
-            if simplfied_key.startswith("owner"):
-                deleted_keys.add("owner")
-            elif simplfied_key.startswith("items.owner"):
-                deleted_keys.add(key[0 : key.find("owner") + len("owner")])
-            elif simplfied_key.startswith("acl"):
-                deleted_keys.add("acl")
-            elif simplfied_key.startswith("items.acl"):
-                deleted_keys.add(key[0 : key.find("acl") + len("acl")])
-            elif simplfied_key.startswith("defaultObjectAcl"):
-                deleted_keys.add("defaultObjectAcl")
-            elif simplfied_key.startswith("items.defaultObjectAcl"):
-                deleted_keys.add(
-                    key[0 : key.find("defaultObjectAcl") + len("defaultObjectAcl")]
-                )
-            else:
-                maybe_delete = True
         if fields is not None:
-            if maybe_delete:
-                for field in fields:
-                    if field != "" and simplfied_key.startswith(field):
-                        maybe_delete = False
-                        break
-                if maybe_delete:
-                    deleted_keys.add(key)
+            for field in fields:
+                if field != "" and not (key.startswith(field) or field.startswith(key)):
+                    keys_to_delete.add(key)
+
     proxy = scalpl.Cut(response)
-    for key in deleted_keys:
-        del proxy[key]
+    for key in keys_to_delete:
+        if proxy.get(key)is not None:
+            del proxy[key]
     return proxy.data
 
 

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -238,20 +238,29 @@ def parse_fields(fields):
 def filter_response_rest(response, projection, fields):
     if fields is not None:
         fields = parse_fields(fields)
+    print(fields)
     keys_to_delete = set()
-    if projection == 'noAcl':
+    if projection == "noAcl":
         keys_to_delete.add("owner")
         keys_to_delete.add("acl")
         keys_to_delete.add("defaultObjectAcl")
     for key in nested_key(response):
+        simplfied_key = remove_index(key)
         if fields is not None:
+            delete = True
             for field in fields:
-                if field != "" and not (key.startswith(field) or field.startswith(key)):
-                    keys_to_delete.add(key)
+                if field != "" and (simplfied_key.startswith(field) or field.startswith(simplfied_key)):
+                    print(simplfied_key)
+                    delete = False
+                    break
+            if delete:
+                keys_to_delete.add(key)
 
     proxy = scalpl.Cut(response)
+    print(proxy)
+    print(keys_to_delete)
     for key in keys_to_delete:
-        if proxy.get(key)is not None:
+        if proxy.get(key) is not None:
             del proxy[key]
     return proxy.data
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -271,10 +271,15 @@ class TestCommonUtils(unittest.TestCase):
             [
                 "name",
                 "acl[0].id",
+                "acl[0]",
                 "acl[1].id",
+                "acl[1]",
+                "acl",
                 "labels.first",
                 "labels.second[0]",
                 "labels.second[1]",
+                "labels.second",
+                "labels",
             ],
         )
 


### PR DESCRIPTION
A bug was happening where fields wasn't working properly and it was
leaving nested empty dicts in the response. This should clear that up,
by changing nested_keys function so that it includes parent keys also.