### PR TITLE
cleanup: grpcio-tools is not needed to install/run

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ It is useful as well to test features that are not yet deployed to production: y
     * keep this virtual environment active whenever you run the testbench
 5. Install dependencies: 
     ```bash
-    pip install -r requirements.txt
+    pip install -e .
     ```
     
 ### Run the testbench
@@ -107,6 +107,7 @@ cd $HOME
 git clone https://github.com/googleapis/googleapis
 patch -p1 <$HOME/storage-testbench/patches/rpo-and-cdr.patch
 cd $HOME/storage-testbench
+pip install grpcio-tools
 python -m grpc_tools.protoc -I$HOME/googleapis \
     --python_out=. --grpc_python_out=. \
     $HOME/googleapis/google/iam/v1/iam_policy.proto

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "grpcio==1.41.0",
-        "grpcio-tools==1.40.0",
         "googleapis-common-protos==1.53.0",
         "protobuf==3.18.0",
         "flask==2.0.1",


### PR DESCRIPTION
This dependency is only needed for development, and then only rarely.
