### PR TITLE
chore: update version post v0.8.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="googleapis-storage-testbench",
-    version="0.8.0",
+    version="0.9.0",
     author="Google LLC",
     author_email="googleapis-packages@google.com",
     description="A testbench for Google Cloud Storage client libraries",


### PR DESCRIPTION
Update setup.py to reflect new tagged release v0.8.0.

Question: @coryan shouldn't this version be v0.9.0 or am I missing context?