### PR TITLE
feat: support additional x-goog-* headers

### DIFF
--- a/gcs/object.py
+++ b/gcs/object.py
@@ -417,7 +417,7 @@ class Object:
                 response_payload = response_payload[-last:]
 
         streamer, length, headers = None, len(response_payload), {}
-        content_range = "bytes %d-%d/%d" % (begin, end - 1, length)
+        content_range = "bytes %d-%d/%d" % (begin, end - 1, len(self.media))
 
         instructions = testbench.common.extract_instruction(request, None)
         if instructions == "return-broken-stream":
@@ -520,4 +520,6 @@ class Object:
         headers["Content-Range"] = content_range
         headers["x-goog-hash"] = self.x_goog_hash_header()
         headers["x-goog-generation"] = self.metadata.generation
+        headers["x-goog-metageneration"] = self.metadata.metageneration
+        headers["x-goog-storage-class"] = self.metadata.storage_class
         return flask.Response(streamer(), status=200, headers=headers)

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -73,7 +73,10 @@ def xml_put_object(bucket_name, object_name):
 def xml_get_object(bucket_name, object_name):
     fake_request = testbench.common.FakeRequest.init_xml(flask.request)
     blob = db.get_object(fake_request, bucket_name, object_name, False, None)
-    return blob.rest_media(fake_request)
+    response = blob.rest_media(fake_request)
+    response.headers["x-goog-stored-content-length"] = len(blob.media)
+    response.headers["x-goog-stored-content-encoding"] = "identity"
+    return response
 
 
 @root.route("/<path:object_name>", subdomain="<bucket_name>")

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -658,6 +658,10 @@ class TestObject(unittest.TestCase):
         response = blob.rest_media(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, b"How vexingly quick daft zebras jump!")
+        self.assertIn("x-goog-hash", response.headers)
+        self.assertIn("x-goog-generation", response.headers)
+        self.assertIn("x-goog-metageneration", response.headers)
+        self.assertIn("x-goog-storage-class", response.headers)
 
         cases = {
             "bytes=4-9": b"vexing",
@@ -675,6 +679,12 @@ class TestObject(unittest.TestCase):
             response = blob.rest_media(request)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data, expected)
+            self.assertIn("content-range", response.headers)
+            content_range = response.headers["content-range"]
+            self.assertTrue(
+                content_range.endswith("/%d" % len(blob.media)),
+                msg="unexpected content-range header: " + content_range,
+            )
 
     def test_rest_media_instructions(self):
         boundary, payload = format_multipart_upload(

--- a/tests/test_testbench_object_xml.py
+++ b/tests/test_testbench_object_xml.py
@@ -52,6 +52,8 @@ class TestTestbenchObjectXML(unittest.TestCase):
             "/fox.txt", base_url="https://bucket-name.storage.googleapis.com"
         )
         self.assertEqual(response.status_code, 200, msg=response.data)
+        self.assertIn("x-goog-stored-content-length", response.headers)
+        self.assertIn("x-goog-stored-content-encoding", response.headers)
         self.assertEqual(response.data, b"The quick brown fox jumps over the lazy dog")
 
     def test_object_xml_put_get_with_bucket(self):


### PR DESCRIPTION
The testbench was not generating some `x-goog-*` headers. I will need
these headers in the C++ client library.
