### PR TITLE
cleanup: simplify pre-condition handling

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -321,6 +321,28 @@ class TestCommonUtils(unittest.TestCase):
         )
         self.assertEqual(len(preconditions), 4)
 
+    def test_make_json_preconditions_source(self):
+        preconditions = testbench.common.make_json_preconditions(
+            prefix="ifSource",
+            request=Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={
+                        "ifSourceGenerationMatch": "5",
+                        "ifSourceGenerationNotMatch": "5",
+                        "ifSourceMetagenerationMatch": "5",
+                        "ifSourceMetagenerationNotMatch": "5",
+                    },
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 4)
+
     def test_make_json_preconditions_if_generation_match(self):
         preconditions = testbench.common.make_json_preconditions(
             Request(
@@ -534,155 +556,6 @@ class TestCommonUtils(unittest.TestCase):
             ),
         )
         self.assertEqual(len(preconditions), 0)
-
-    def test_make_json_preconditions_many(self):
-        preconditions = testbench.common.make_json_preconditions(
-            Request(
-                create_environ(
-                    base_url="http://localhost:8080",
-                    content_length=0,
-                    data="",
-                    content_type="application/octet-stream",
-                    method="POST",
-                    headers={},
-                    query_string={
-                        "ifGenerationMatch": "5",
-                        "ifGenerationNotMatch": "5",
-                        "ifMetagenerationMatch": "5",
-                        "ifMetagenerationNotMatch": "5",
-                    },
-                )
-            ),
-        )
-        self.assertEqual(len(preconditions), 4)
-
-    def test_make_json_preconditions_source(self):
-        preconditions = testbench.common.make_json_preconditions(
-            prefix="ifSource",
-            request=Request(
-                create_environ(
-                    base_url="http://localhost:8080",
-                    content_length=0,
-                    data="",
-                    content_type="application/octet-stream",
-                    method="POST",
-                    headers={},
-                    query_string={
-                        "ifSourceGenerationMatch": "5",
-                        "ifSourceGenerationNotMatch": "5",
-                        "ifSourceMetagenerationMatch": "5",
-                        "ifSourceMetagenerationNotMatch": "5",
-                    },
-                )
-            ),
-        )
-        self.assertEqual(len(preconditions), 4)
-
-    def test_make_json_preconditions_if_generation_match(self):
-        preconditions = testbench.common.make_json_preconditions(
-            Request(
-                create_environ(
-                    base_url="http://localhost:8080",
-                    content_length=0,
-                    data="",
-                    content_type="application/octet-stream",
-                    method="POST",
-                    headers={},
-                    query_string={"ifGenerationMatch": "5"},
-                )
-            ),
-        )
-        self.assertEqual(len(preconditions), 1)
-        blob = types.SimpleNamespace(metadata=storage_pb2.Object(generation=5))
-        self.assertTrue(preconditions[0](blob, 5, None))
-
-        with self.assertRaises(testbench.error.RestException) as rest:
-            preconditions[0](blob, 6, None)
-        self.assertEqual(rest.exception.code, 412)
-
-    def test_make_json_preconditions_if_generation_not_match(self):
-        preconditions = testbench.common.make_json_preconditions(
-            Request(
-                create_environ(
-                    base_url="http://localhost:8080",
-                    content_length=0,
-                    data="",
-                    content_type="application/octet-stream",
-                    method="POST",
-                    headers={},
-                    query_string={"ifGenerationNotMatch": "5"},
-                )
-            ),
-        )
-        self.assertEqual(len(preconditions), 1)
-        blob = types.SimpleNamespace(metadata=storage_pb2.Object(generation=5))
-        self.assertTrue(preconditions[0](blob, 6, None))
-
-        with self.assertRaises(testbench.error.RestException) as rest:
-            preconditions[0](blob, 5, None)
-        self.assertEqual(rest.exception.code, 304)
-
-    def test_make_json_preconditions_if_metageneration_match(self):
-        preconditions = testbench.common.make_json_preconditions(
-            Request(
-                create_environ(
-                    base_url="http://localhost:8080",
-                    content_length=0,
-                    data="",
-                    content_type="application/octet-stream",
-                    method="POST",
-                    headers={},
-                    query_string={"ifMetagenerationMatch": "5"},
-                )
-            ),
-        )
-        self.assertEqual(len(preconditions), 1)
-        self.assertTrue(
-            preconditions[0](
-                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=5)),
-                3,
-                None,
-            )
-        )
-
-        with self.assertRaises(testbench.error.RestException) as rest:
-            preconditions[0](
-                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=6)),
-                3,
-                None,
-            )
-        self.assertEqual(rest.exception.code, 412)
-
-    def test_make_json_preconditions_if_metageneration_not_match(self):
-        preconditions = testbench.common.make_json_preconditions(
-            Request(
-                create_environ(
-                    base_url="http://localhost:8080",
-                    content_length=0,
-                    data="",
-                    content_type="application/octet-stream",
-                    method="POST",
-                    headers={},
-                    query_string={"ifMetagenerationNotMatch": "5"},
-                )
-            ),
-        )
-        self.assertEqual(len(preconditions), 1)
-        self.assertTrue(
-            preconditions[0](
-                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=6)),
-                3,
-                None,
-            )
-        )
-
-        with self.assertRaises(testbench.error.RestException) as rest:
-            preconditions[0](
-                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=5)),
-                3,
-                None,
-            )
-        self.assertEqual(rest.exception.code, 304)
 
     def test_extract_projection(self):
         request = testbench.common.FakeRequest(args={})

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -541,22 +541,6 @@ class TestCommonUtils(unittest.TestCase):
             )
         self.assertEqual(rest.exception.code, 412)
 
-    def test_make_json_preconditions_empty(self):
-        preconditions = testbench.common.make_json_preconditions(
-            Request(
-                create_environ(
-                    base_url="http://localhost:8080",
-                    content_length=0,
-                    data="",
-                    content_type="application/octet-stream",
-                    method="POST",
-                    headers={},
-                    query_string={},
-                )
-            ),
-        )
-        self.assertEqual(len(preconditions), 0)
-
     def test_extract_projection(self):
         request = testbench.common.FakeRequest(args={})
         projection = testbench.common.extract_projection(request, "noAcl", None)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -19,6 +19,7 @@
 import base64
 import hashlib
 import json
+import types
 import unittest
 
 import flask
@@ -282,6 +283,406 @@ class TestCommonUtils(unittest.TestCase):
                 "labels",
             ],
         )
+
+    def test_make_json_preconditions_empty(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 0)
+
+    def test_make_json_preconditions_many(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={
+                        "ifGenerationMatch": "5",
+                        "ifGenerationNotMatch": "5",
+                        "ifMetagenerationMatch": "5",
+                        "ifMetagenerationNotMatch": "5",
+                    },
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 4)
+
+    def test_make_json_preconditions_if_generation_match(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={"ifGenerationMatch": "5"},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 1)
+        blob = types.SimpleNamespace(metadata=storage_pb2.Object(generation=5))
+        self.assertTrue(preconditions[0](blob, 5, None))
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            preconditions[0](blob, 6, None)
+        self.assertEqual(rest.exception.code, 412)
+
+    def test_make_json_preconditions_if_generation_not_match(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={"ifGenerationNotMatch": "5"},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 1)
+        blob = types.SimpleNamespace(metadata=storage_pb2.Object(generation=5))
+        self.assertTrue(preconditions[0](blob, 6, None))
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            preconditions[0](blob, 5, None)
+        self.assertEqual(rest.exception.code, 304)
+
+    def test_make_json_preconditions_if_metageneration_match(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={"ifMetagenerationMatch": "5"},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 1)
+        self.assertTrue(
+            preconditions[0](
+                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=5)),
+                3,
+                None,
+            )
+        )
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            preconditions[0](
+                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=6)),
+                3,
+                None,
+            )
+        self.assertEqual(rest.exception.code, 412)
+
+    def test_make_json_preconditions_if_metageneration_not_match(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={"ifMetagenerationNotMatch": "5"},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 1)
+        self.assertTrue(
+            preconditions[0](
+                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=6)),
+                3,
+                None,
+            )
+        )
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            preconditions[0](
+                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=5)),
+                3,
+                None,
+            )
+        self.assertEqual(rest.exception.code, 304)
+
+    def test_make_xml_preconditions_empty(self):
+        preconditions = testbench.common.make_xml_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 0)
+
+    def test_make_xml_preconditions_many(self):
+        preconditions = testbench.common.make_xml_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={
+                        "x-goog-if-generation-match": 42,
+                        "x-goog-if-metageneration-match": 42,
+                    },
+                    query_string={},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 2)
+
+    def test_make_xml_preconditions_if_generation_match(self):
+        preconditions = testbench.common.make_xml_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={
+                        "x-goog-if-generation-match": 42,
+                    },
+                    query_string={},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 1)
+        blob = types.SimpleNamespace(metadata=storage_pb2.Object(generation=42))
+        self.assertTrue(preconditions[0](blob, 42, None))
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            preconditions[0](blob, 43, None)
+        self.assertEqual(rest.exception.code, 412)
+
+    def test_make_xml_preconditions_if_metageneration_match(self):
+        preconditions = testbench.common.make_xml_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={
+                        "x-goog-if-metageneration-match": 42,
+                    },
+                    query_string={},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 1)
+        self.assertTrue(
+            preconditions[0](
+                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=42)),
+                3,
+                None,
+            )
+        )
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            preconditions[0](
+                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=43)),
+                3,
+                None,
+            )
+        self.assertEqual(rest.exception.code, 412)
+
+    def test_make_json_preconditions_empty(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 0)
+
+    def test_make_json_preconditions_many(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={
+                        "ifGenerationMatch": "5",
+                        "ifGenerationNotMatch": "5",
+                        "ifMetagenerationMatch": "5",
+                        "ifMetagenerationNotMatch": "5",
+                    },
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 4)
+
+    def test_make_json_preconditions_source(self):
+        preconditions = testbench.common.make_json_preconditions(
+            prefix="ifSource",
+            request=Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={
+                        "ifSourceGenerationMatch": "5",
+                        "ifSourceGenerationNotMatch": "5",
+                        "ifSourceMetagenerationMatch": "5",
+                        "ifSourceMetagenerationNotMatch": "5",
+                    },
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 4)
+
+    def test_make_json_preconditions_if_generation_match(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={"ifGenerationMatch": "5"},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 1)
+        blob = types.SimpleNamespace(metadata=storage_pb2.Object(generation=5))
+        self.assertTrue(preconditions[0](blob, 5, None))
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            preconditions[0](blob, 6, None)
+        self.assertEqual(rest.exception.code, 412)
+
+    def test_make_json_preconditions_if_generation_not_match(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={"ifGenerationNotMatch": "5"},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 1)
+        blob = types.SimpleNamespace(metadata=storage_pb2.Object(generation=5))
+        self.assertTrue(preconditions[0](blob, 6, None))
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            preconditions[0](blob, 5, None)
+        self.assertEqual(rest.exception.code, 304)
+
+    def test_make_json_preconditions_if_metageneration_match(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={"ifMetagenerationMatch": "5"},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 1)
+        self.assertTrue(
+            preconditions[0](
+                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=5)),
+                3,
+                None,
+            )
+        )
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            preconditions[0](
+                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=6)),
+                3,
+                None,
+            )
+        self.assertEqual(rest.exception.code, 412)
+
+    def test_make_json_preconditions_if_metageneration_not_match(self):
+        preconditions = testbench.common.make_json_preconditions(
+            Request(
+                create_environ(
+                    base_url="http://localhost:8080",
+                    content_length=0,
+                    data="",
+                    content_type="application/octet-stream",
+                    method="POST",
+                    headers={},
+                    query_string={"ifMetagenerationNotMatch": "5"},
+                )
+            ),
+        )
+        self.assertEqual(len(preconditions), 1)
+        self.assertTrue(
+            preconditions[0](
+                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=6)),
+                3,
+                None,
+            )
+        )
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            preconditions[0](
+                types.SimpleNamespace(metadata=storage_pb2.Object(metageneration=5)),
+                3,
+                None,
+            )
+        self.assertEqual(rest.exception.code, 304)
 
     def test_extract_projection(self):
         request = testbench.common.FakeRequest(args={})

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -19,6 +19,7 @@
 import json
 import os
 import unittest
+import unittest.mock
 
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
@@ -121,10 +122,8 @@ class TestDatabaseObject(unittest.TestCase):
         blob, _ = gcs.object.Object.init_media(request, self.bucket.metadata)
         self.database.insert_object(request, "bucket-name", blob, None)
         get_result = self.database.get_object(
-            testbench.common.FakeRequest(args={}),
             "bucket-name",
             "object-name",
-            is_source=True,
             context=None,
         )
         self.assertEqual(get_result.metadata, blob.metadata)
@@ -174,7 +173,11 @@ class TestDatabaseObject(unittest.TestCase):
 
         # Delete the latest version, listing without versions should not include the just deleted object.
         self.database.delete_object(
-            testbench.common.FakeRequest(args={}), "bucket-name", "object-name", None
+            "bucket-name",
+            "object-name",
+            context=None,
+            generation=None,
+            preconditions=[],
         )
         items, _ = self.database.list_object(
             Request(create_environ(query_string={})), "bucket-name", None
@@ -190,10 +193,7 @@ class TestDatabaseObject(unittest.TestCase):
         )
         for o in items:
             self.database.delete_object(
-                testbench.common.FakeRequest(args={"generation": o.generation}),
-                "bucket-name",
-                o.name,
-                None,
+                "bucket-name", o.name, generation=o.generation, context=None
             )
         items, _ = self.database.list_object(
             Request(create_environ(query_string={"versions": "true"})),
@@ -204,13 +204,7 @@ class TestDatabaseObject(unittest.TestCase):
 
     def test_get_object_not_found(self):
         with self.assertRaises(testbench.error.RestException) as rest:
-            _ = self.database.get_object(
-                testbench.common.FakeRequest(args={}),
-                "bucket-name",
-                "object-name",
-                is_source=False,
-                context=None,
-            )
+            _ = self.database.get_object("bucket-name", "object-name", context=None)
         self.assertEqual(rest.exception.code, 404)
 
         request = testbench.common.FakeRequest(
@@ -218,17 +212,57 @@ class TestDatabaseObject(unittest.TestCase):
         )
         blob, _ = gcs.object.Object.init_media(request, self.bucket.metadata)
         self.database.insert_object(request, "bucket-name", blob, None)
+
+        # Verify that mismatched bucket, object, or generation returns 404
         with self.assertRaises(testbench.error.RestException) as rest:
             _ = self.database.get_object(
-                testbench.common.FakeRequest(
-                    args={"generation": blob.metadata.generation + 1}
-                ),
-                "bucket-name",
+                "bad-bucket-name",
                 "object-name",
-                is_source=False,
                 context=None,
             )
         self.assertEqual(rest.exception.code, 404)
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            _ = self.database.get_object(
+                "bucket-name",
+                "bad-object-name",
+                context=None,
+            )
+        self.assertEqual(rest.exception.code, 404)
+
+        bad_generation = blob.metadata.generation + 1
+        with self.assertRaises(testbench.error.RestException) as rest:
+            _ = self.database.get_object(
+                "bucket-name",
+                "object-name",
+                generation=bad_generation,
+                context=None,
+            )
+        self.assertEqual(rest.exception.code, 404)
+
+    def test_get_object_stops_on_first_failed_preconditions(self):
+        with self.assertRaises(testbench.error.RestException) as rest:
+            _ = self.database.get_object("bucket-name", "object-name", context=None)
+        self.assertEqual(rest.exception.code, 404)
+
+        request = testbench.common.FakeRequest(
+            args={"name": "object-name"}, data=b"12345678", headers={}, environ={}
+        )
+        blob, _ = gcs.object.Object.init_media(request, self.bucket.metadata)
+        generation = blob.metadata.generation
+        self.database.insert_object(request, "bucket-name", blob, None)
+
+        works1 = unittest.mock.MagicMock(return_value=True)
+        fails = unittest.mock.MagicMock(return_value=False)
+        works2 = unittest.mock.MagicMock(return_value=True)
+        preconditions = [works1, fails, works2]
+        get = self.database.get_object(
+            "bucket-name", "object-name", context=None, preconditions=preconditions
+        )
+        self.assertIsNone(get)
+        works1.assert_called_once()
+        fails.assert_called_once_with(blob, generation, None)
+        works2.assert_not_called()
 
     def test_list_object_bucket_not_found(self):
         with self.assertRaises(testbench.error.RestException) as rest:


### PR DESCRIPTION
This simplifies pre-condition handling for `Database.get_object()` and
`Database.delete_object()` by asking the caller to provide the
generation (which can be `None` or `0`) and the preconditions as a list
of predicates on the blob and the live generation.

The callers know what the pre-conditions fields are called (e.g.
`ifGenerationMatch` vs. `ifSourceGenerationMatch` for `Objects: copy` or
`Objects: rewrite`). The caller also knows if the generation is a
top-level attribute of the request, or part of a sub-object (or a query
parameter or some other possibilities).

Part of the work for #217 
