### PR TITLE
feat: add support for return-X-after-YK of downloaded data

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ curl -H "x-retry-test-id: 1d05c20627844214a9ff7cbcf696317d" "http://localhost:91
 | Failure Id              | Description
 | ----------------------- | ---
 | return-X                                  | Testbench will fail with HTTP code provided for `X`, e.g. return-503 returns a 503
-| return-X-after-YK                         | Testbench will return X after YKiB of uploaded data
-| return-broken-stream-final-chunk-after-YB | Testbench will break connection on final chunk of a resumable upload after Y bytes.
+| return-X-after-YK                         | Testbench will return X after YKiB of uploaded or downloaded data
+| return-broken-stream-final-chunk-after-YB | Testbench will break connection on final chunk of a resumable upload after Y bytes
 | return-broken-stream                      | Testbench will fail after a few bytes
 | return-reset-connection                   | Testbench will fail with a reset connection

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -677,17 +677,17 @@ def __get_streamer_response_custom_error_fn(database, method, test_id, error_cod
             d = _extract_data(data)
             bytes_downloaded = 0
             for r in range(0, len(d), chunk_size):
+                if bytes_downloaded < limit:
+                    chunk_end = min(r + chunk_size, len(d))
+                    chunk_downloaded = chunk_end - r
+                    bytes_downloaded += chunk_downloaded
+                    yield d[r:chunk_end]
                 if bytes_downloaded >= limit:
                     database.dequeue_next_instruction(test_id, method)
                     raise testbench.error.RestException(
                         f"Retry Test: Caused a {error_code}. Fault injected after downloading {bytes_downloaded} bytes",
                         error_code
                     )
-                else:
-                    chunk_end = min(r + chunk_size, len(d))
-                    chunk_downloaded = chunk_end - r
-                    bytes_downloaded += chunk_downloaded
-                    yield d[r:chunk_end]
 
         # Inject fault outside of the streamer considering execution flow and werkzeug wrappers
         try:

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -781,6 +781,7 @@ def handle_retry_test_instruction(database, request, method):
                     grpc_code=StatusCode.INTERNAL,  # not really used
                     context=None,
                 )
+    # TODO(cathyo@): introduce Retry Test API method "storage.objects.download" for large file downloads
     if error_after_bytes_matches and method == "storage.objects.get":
         items = list(error_after_bytes_matches.groups())
         error_code = int(items[0])

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -671,7 +671,9 @@ def __get_streamer_response_fn(database, method, conn, test_id):
     return response_handler
 
 
-def __get_streamer_response_custom_error_fn(database, method, test_id, error_code, limit, chunk_size=4):
+def __get_streamer_response_custom_error_fn(
+    database, method, test_id, error_code, limit, chunk_size=4
+):
     def response_handler(data):
         def streamer():
             d = _extract_data(data)
@@ -686,7 +688,7 @@ def __get_streamer_response_custom_error_fn(database, method, test_id, error_cod
                     database.dequeue_next_instruction(test_id, method)
                     raise testbench.error.RestException(
                         f"Retry Test: Caused a {error_code}. Fault injected after downloading {bytes_downloaded} bytes",
-                        error_code
+                        error_code,
                     )
 
         # Inject fault outside of the streamer considering execution flow and werkzeug wrappers
@@ -786,7 +788,9 @@ def handle_retry_test_instruction(database, request, method):
         items = list(error_after_bytes_matches.groups())
         error_code = int(items[0])
         after_bytes = int(items[1]) * 1024
-        return __get_streamer_response_custom_error_fn(database, method, test_id, error_code, after_bytes)
+        return __get_streamer_response_custom_error_fn(
+            database, method, test_id, error_code, after_bytes
+        )
     retry_return_short_response = testbench.common.retry_return_short_response.match(
         next_instruction
     )


### PR DESCRIPTION
Fixes #273

As part of the GCS client library retry alignment project, this adds support in the Retry Test API to `return-X-after-YK` of **downloaded** data.

I've noted a TODO entry to introduce a Retry Test API method "storage.objects.download" to further support complex download test cases for larger files.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR