### PR TITLE
feat: add support for return-broken-stream-after-YK

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,6 @@ curl -H "x-retry-test-id: 1d05c20627844214a9ff7cbcf696317d" "http://localhost:91
 | return-X                                  | Testbench will fail with HTTP code provided for `X`, e.g. return-503 returns a 503
 | return-X-after-YK                         | Testbench will return X after YKiB of uploaded data
 | return-broken-stream-final-chunk-after-YB | Testbench will break connection on final chunk of a resumable upload after Y bytes
-| return-broken-stream                      | Testbench will fail after a few bytes of downloaded data
+| return-broken-stream                      | Testbench will fail after a few bytes
 | return-broken-stream-after-YK             | Testbench will fail after YKiB of downloaded data
 | return-reset-connection                   | Testbench will fail with a reset connection

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ curl -H "x-retry-test-id: 1d05c20627844214a9ff7cbcf696317d" "http://localhost:91
 | ----------------------- | ---
 | return-X                                  | Testbench will fail with HTTP code provided for `X`, e.g. return-503 returns a 503
 | return-X-after-YK                         | Testbench will return X after YKiB of uploaded data
-| return-broken-stream-final-chunk-after-YB | Testbench will break connection on final chunk of a resumable upload after Y bytes.
-| return-broken-stream                      | Testbench will fail after a few bytes
+| return-broken-stream-final-chunk-after-YB | Testbench will break connection on final chunk of a resumable upload after Y bytes
+| return-broken-stream                      | Testbench will fail after a few bytes of downloaded data
+| return-broken-stream-after-YK             | Testbench will fail after YKiB of downloaded data
 | return-reset-connection                   | Testbench will fail with a reset connection

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -736,7 +736,7 @@ def handle_retry_test_instruction(database, request, method):
             raise testbench.error.RestException(
                 "Injected 'connection reset by peer' fault", 500
             )
-        elif items[0] == "broken-stream" and method == "storage.objects.get":
+        elif items[0] == "broken-stream":
             conn = request.environ.get("gunicorn.socket", None)
             return __get_streamer_response_fn(database, method, conn, test_id)
     broken_stream_after_bytes = (

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -396,6 +396,7 @@ class Database:
             testbench.common.retry_return_error_connection,
             testbench.common.retry_return_error_after_bytes,
             testbench.common.retry_return_short_response,
+            testbench.common.retry_return_broken_stream_after_bytes,
         ]:
             if expr.match(failure) is not None:
                 return

--- a/tests/test_testbench_retry.py
+++ b/tests/test_testbench_retry.py
@@ -368,7 +368,7 @@ class TestTestbenchRetry(unittest.TestCase):
         )
         with self.assertRaises(testbench.error.RestException) as ex:
             _ = len(response.data)
-        self.assertIn("connection reset by peer", ex.exception.msg)
+        self.assertIn("broken stream", ex.exception.msg)
 
     def test_retry_test_return_broken_stream_after_bytes(self):
         response = self.client.post(
@@ -427,7 +427,7 @@ class TestTestbenchRetry(unittest.TestCase):
         )
         with self.assertRaises(testbench.error.RestException) as ex:
             _ = len(response.data)
-        self.assertIn("connection reset by peer", ex.exception.msg)
+        self.assertIn("broken stream", ex.exception.msg)
 
     def test_retry_test_return_error_after_bytes(self):
         response = self.client.post(


### PR DESCRIPTION
Fixes #173

This introduces support for `return-broken-stream-after-YK` of downloaded data in the Retry Test API. 
To better test complex download scenarios in the retry conformance tests, we've discussed to test larger files and add support for "after-YK" instead of "after-YB"

- [X] Tests pass
- [X] Appropriate changes to README are included in PR