### PR TITLE
fix(grpc): correct prefix for project resources

### DIFF
--- a/gcs/bucket.py
+++ b/gcs/bucket.py
@@ -318,7 +318,7 @@ class Bucket:
             {
                 "name": lambda x: ("name", bucket_id),
                 "bucketId": lambda x: ("id", bucket_id),
-                "project": lambda x: ("projectNumber", x.replace("project/", "")),
+                "project": lambda x: ("projectNumber", x.replace("projects/", "")),
                 "createTime": lambda x: ("timeCreated", x),
                 "updateTime": lambda x: ("updated", x),
                 "iamConfig": lambda x: (
@@ -452,7 +452,7 @@ class Bucket:
             )
         metadata.iam_config.uniform_bucket_level_access.enabled = is_uniform
         metadata.bucket_id = testbench.common.bucket_name_from_proto(metadata.name)
-        metadata.project = "project/" + testbench.acl.PROJECT_NUMBER
+        metadata.project = "projects/" + testbench.acl.PROJECT_NUMBER
         return (
             cls(metadata, {}, cls.__init_iam_policy(metadata, context)),
             testbench.common.extract_projection(request, default_projection, context),

--- a/tests/test_bucket_grpc.py
+++ b/tests/test_bucket_grpc.py
@@ -43,6 +43,9 @@ class TestBucketGrpc(unittest.TestCase):
         self.assertEqual(bucket.metadata.storage_class, "REGIONAL")
         self.assertLess(0, bucket.metadata.metageneration)
 
+        rest = bucket.rest()
+        self.assertNotEqual(int(rest.get("projectNumber")), 0)
+
     def test_init_validates_names(self):
         request = storage_pb2.CreateBucketRequest(
             parent="projects/test-project",

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -89,6 +89,7 @@ class TestGrpc(unittest.TestCase):
         response = self.grpc.CreateBucket(request, context)
         self.assertEqual(response.name, "projects/_/buckets/test-bucket-name")
         self.assertEqual(response.bucket_id, "test-bucket-name")
+        self.assertTrue(response.project.startswith("projects/"))
 
     def test_create_bucket_predefined_acls(self):
         acls = [


### PR DESCRIPTION
This was breaking some of my integration tests for the C++ client library, but only for buckets created with gRPC. Sigh.
