### PR TITLE
feat: allow retry method storage.objects.download for testing

### DIFF
--- a/testbench/common.py
+++ b/testbench/common.py
@@ -742,7 +742,10 @@ def handle_retry_test_instruction(database, request, method):
     broken_stream_after_bytes = (
         testbench.common.retry_return_broken_stream_after_bytes.match(next_instruction)
     )
-    if broken_stream_after_bytes and method in ["storage.objects.get", "storage.objects.download"]:
+    if broken_stream_after_bytes and method in [
+        "storage.objects.get",
+        "storage.objects.download",
+    ]:
         items = list(broken_stream_after_bytes.groups())
         after_bytes = int(items[0]) * 1024
         conn = request.environ.get("gunicorn.socket", None)

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -742,7 +742,7 @@ def handle_retry_test_instruction(database, request, method):
     broken_stream_after_bytes = (
         testbench.common.retry_return_broken_stream_after_bytes.match(next_instruction)
     )
-    if broken_stream_after_bytes and method == "storage.objects.get":
+    if broken_stream_after_bytes and method in ["storage.objects.get", "storage.objects.download"]:
         items = list(broken_stream_after_bytes.groups())
         after_bytes = int(items[0]) * 1024
         conn = request.environ.get("gunicorn.socket", None)

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -541,6 +541,7 @@ def object_delete(bucket_name, object_name):
 
 @gcs.route("/b/<bucket_name>/o/<path:object_name>")
 @retry_test(method="storage.objects.get")
+@retry_test(method="storage.objects.download")
 def object_get(bucket_name, object_name):
     blob = db.get_object(
         bucket_name,

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -541,7 +541,6 @@ def object_delete(bucket_name, object_name):
 
 @gcs.route("/b/<bucket_name>/o/<path:object_name>")
 @retry_test(method="storage.objects.get")
-@retry_test(method="storage.objects.download")
 def object_get(bucket_name, object_name):
     blob = db.get_object(
         bucket_name,
@@ -863,6 +862,7 @@ download.register_error_handler(Exception, testbench.error.RestException.handler
 
 
 @download.route("/b/<bucket_name>/o/<path:object_name>")
+@retry_test(method="storage.objects.download")
 def download_object_get(bucket_name, object_name):
     return object_get(bucket_name, object_name)
 

--- a/tests/test_testbench_retry.py
+++ b/tests/test_testbench_retry.py
@@ -394,7 +394,11 @@ class TestTestbenchRetry(unittest.TestCase):
         self.assertEqual(blob_smaller.status_code, 200)
 
         # Setup a failure for reading back the object.
-        for method in ["storage.objects.get", "storage.objects.download"]:
+        cases = {
+            "storage.objects.get": "/storage/v1/b/bucket-name/o/",
+            "storage.objects.download": "/download/storage/v1/b/bucket-name/o/",
+        }
+        for method, endpoint in cases.items():
             response = self.client.post(
                 "/retry_test",
                 data=json.dumps(
@@ -411,7 +415,7 @@ class TestTestbenchRetry(unittest.TestCase):
 
             # The 128-bytes file is too small to trigger the "return-504-after-256K" fault injection.
             response = self.client.get(
-                "/storage/v1/b/bucket-name/o/128.txt",
+                endpoint + "128.txt",
                 query_string={"alt": "media"},
                 headers={"x-retry-test-id": id},
             )
@@ -419,7 +423,7 @@ class TestTestbenchRetry(unittest.TestCase):
 
             # The 256KiB file triggers the "return-broken-stream-after-256K" fault injection.
             response = self.client.get(
-                "/storage/v1/b/bucket-name/o/256k.txt",
+                endpoint + "256k.txt",
                 query_string={"alt": "media"},
                 headers={"x-retry-test-id": id},
             )


### PR DESCRIPTION
Fixes #283

Adds and allows retry method `storage.objects.download` for testing purposes. 
This can help distinguish test cases that are performing media operations from metadata get.
- [X] Tests pass
