### PR TITLE
fix(grpc): align grpc TestIamPermissions with http

### DIFF
--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -135,9 +135,9 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
     def TestIamPermissions(self, request, context):
         # If the bucket does not exist this will return an error
         _ = self.db.get_bucket(request.resource, context)
-        # We do not implement IAM functionality, just return something moderately sensible:
+        # We do not implement IAM functionality, just echo the request permissions back:
         return iam_policy_pb2.TestIamPermissionsResponse(
-            permissions=[p for p in request.permissions if p.startswith("storage.")]
+            permissions=request.permissions
         )
 
     def UpdateBucket(self, request, context):

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -363,20 +363,21 @@ class TestGrpc(unittest.TestCase):
 
     def test_test_iam_permissions(self):
         context = unittest.mock.Mock()
+        permissions = [
+            "storage.buckets.create",
+            "storage.objects.create",
+            "not-storage.thing.get",
+        ]
         response = self.grpc.TestIamPermissions(
             iam_policy_pb2.TestIamPermissionsRequest(
                 resource="projects/_/buckets/bucket-name",
-                permissions=[
-                    "storage.buckets.create",
-                    "storage.objects.create",
-                    "not-storage.thing.get",
-                ],
+                permissions=permissions,
             ),
             context,
         )
         self.assertEqual(
             set(response.permissions),
-            {"storage.buckets.create", "storage.objects.create"},
+            permissions,
         )
 
     def test_update_bucket(self):

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -363,11 +363,11 @@ class TestGrpc(unittest.TestCase):
 
     def test_test_iam_permissions(self):
         context = unittest.mock.Mock()
-        permissions = [
+        permissions = {
             "storage.buckets.create",
             "storage.objects.create",
             "not-storage.thing.get",
-        ]
+        }
         response = self.grpc.TestIamPermissions(
             iam_policy_pb2.TestIamPermissionsRequest(
                 resource="projects/_/buckets/bucket-name",


### PR DESCRIPTION
Fix gRPC implementation of TestIamPermissions to echo the request `permissions` back in the response unfiltered. This is the behavior of the HTTP implementation, and they should be consistent. Since the HTTP implementation preceded the gRPC one, and the gRPC behavior was more restrictive, in order to retain backwards compatibility for existing HTTP tests, gRPC must be adjusted to match HTTP rather than the other way around.