### PR TITLE
fix: prepend bucket name prefix for both transports

### DIFF
--- a/testbench/database.py
+++ b/testbench/database.py
@@ -104,6 +104,7 @@ class Database:
             if not prefix:
                 return self._buckets.values()
 
+            prefix = "projects/_/buckets/" + prefix
             buckets = []
             for bucket in self._buckets.values():
                 name = bucket.metadata.name

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -67,8 +67,6 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
             )
         project = request.parent[len("projects/") :]
         prefix = request.prefix
-        if prefix:
-            prefix = "projects/_/buckets/" + prefix
 
         if len(request.read_mask.paths) == 0:
             # By default we need to filter out `acl`, `default_object_acl`, and `owner`


### PR DESCRIPTION
I thought only grpc-created buckets had the bucket name prefixed as a resource, but both do. This meant that http List Bucket calls with Prefix never worked unless the full project resource name was also part of the prefix.

Fixes the fix for #314.