### PR TITLE
fix: default to resumable uploadType if not passed in query param, return location as X-Good-Upload-URL header

### DIFF
--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -879,7 +879,7 @@ upload.register_error_handler(Exception, testbench.error.RestException.handler)
 def object_insert(bucket_name):
     db.insert_test_bucket()
     bucket = db.get_bucket(bucket_name, None).metadata
-    upload_type = flask.request.args.get("uploadType")
+    upload_type = flask.request.args.get("uploadType", "resumable")
     if upload_type is None:
         testbench.error.missing("uploadType", None)
     elif upload_type not in {"multipart", "media", "resumable"}:
@@ -889,6 +889,7 @@ def object_insert(bucket_name):
         db.insert_upload(upload)
         response = flask.make_response("")
         response.headers["Location"] = upload.location
+        response.headers["X-Goog-Upload-URL"] = upload.location
         return response
     blob, projection = None, ""
     if upload_type == "media":

--- a/tests/test_testbench_object_upload.py
+++ b/tests/test_testbench_object_upload.py
@@ -464,15 +464,16 @@ class TestTestbenchObjectUpload(unittest.TestCase):
         query_rest.pop("owner")
         self.assertEqual(insert_rest, query_rest)
 
-    def test_upload_validate_upload_type(self):
+    def test_upload_empty_upload_type(self):
         response = self.client.post(
             "/upload/storage/v1/b/bucket-name/o",
             query_string={"name": "zebra"},
             content_type="text/plain",
             data="",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
 
+    def test_upload_validate_upload_type(self):
         response = self.client.post(
             "/upload/storage/v1/b/bucket-name/o",
             query_string={"name": "zebra", "uploadType": "invalid"},


### PR DESCRIPTION
1. From Ruby library, we do not send `uploadType` as a query parameter, the first time we call upload object API. Since, we default to `resumable` upload type anyway at the end, I thought it'd be a good idea to set it to default if not passed in query param.
2. Ruby client lib also looks for header `X-Goog-Upload-URL`  to make next API call.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR