### PR TITLE
ci: stop testing with Python 3.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     name: Unit Tests with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.6 went EOL about 4 months ago.
