### PR TITLE
feat: enrich `ObjectAccessControl` REST responses

### DIFF
--- a/testbench/common.py
+++ b/testbench/common.py
@@ -916,7 +916,7 @@ def preprocess_object_metadata(metadata):
     # them if present, ignore then otherwise
     if "acl" in md:
         for a in md["acl"]:
-            for field in ["kind", "bucket", "object", "generation"]:
+            for field in ["kind", "bucket", "object", "generation", "etag"]:
                 a.pop(field, None)
     return md
 

--- a/testbench/proto2rest.py
+++ b/testbench/proto2rest.py
@@ -28,7 +28,6 @@ This module contains a number of helper functions to perform these transformatio
 
 import base64
 import hashlib
-from os import access
 import struct
 
 from google.protobuf import json_format

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -761,11 +761,15 @@ def object_acl_list(bucket_name, object_name):
         preconditions=testbench.common.make_json_preconditions(flask.request),
         context=None,
     )
-    response = {"kind": "storage#objectAccessControls", "items": []}
-    for acl in blob.metadata.acl:
-        acl_rest = json_format.MessageToDict(acl)
-        acl_rest["kind"] = "storage#objectAccessControl"
-        response["items"].append(acl_rest)
+    response = {
+        "kind": "storage#objectAccessControls",
+        "items": [
+            testbench.proto2rest.object_access_control_as_rest(
+                bucket_name, object_name, str(blob.metadata.generation), a
+            )
+            for a in blob.metadata.acl
+        ],
+    }
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(response, None, fields)
 
@@ -781,8 +785,9 @@ def object_acl_insert(bucket_name, object_name):
         context=None,
     )
     acl = blob.insert_acl(flask.request, None)
-    response = json_format.MessageToDict(acl)
-    response["kind"] = "storage#objectAccessControl"
+    response = testbench.proto2rest.object_access_control_as_rest(
+        bucket_name, object_name, str(blob.metadata.generation), acl
+    )
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(response, None, fields)
 
@@ -798,8 +803,9 @@ def object_acl_get(bucket_name, object_name, entity):
         context=None,
     )
     acl = blob.get_acl(entity, None)
-    response = json_format.MessageToDict(acl)
-    response["kind"] = "storage#objectAccessControl"
+    response = testbench.proto2rest.object_access_control_as_rest(
+        bucket_name, object_name, str(blob.metadata.generation), acl
+    )
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(response, None, fields)
 
@@ -815,8 +821,9 @@ def object_acl_update(bucket_name, object_name, entity):
         context=None,
     )
     acl = blob.update_acl(flask.request, entity, None)
-    response = json_format.MessageToDict(acl)
-    response["kind"] = "storage#objectAccessControl"
+    response = testbench.proto2rest.object_access_control_as_rest(
+        bucket_name, object_name, str(blob.metadata.generation), acl
+    )
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(response, None, fields)
 
@@ -835,8 +842,9 @@ def object_acl_patch(bucket_name, object_name, entity):
         context=None,
     )
     acl = blob.patch_acl(flask.request, entity, None)
-    response = json_format.MessageToDict(acl)
-    response["kind"] = "storage#objectAccessControl"
+    response = testbench.proto2rest.object_access_control_as_rest(
+        bucket_name, object_name, str(blob.metadata.generation), acl
+    )
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(response, None, fields)
 
@@ -852,7 +860,7 @@ def object_acl_delete(bucket_name, object_name, entity):
         context=None,
     )
     blob.delete_acl(entity, None)
-    return ""
+    return flask.make_response("")
 
 
 # Define the WSGI application to handle bucket requests.


### PR DESCRIPTION
Always use the helper functions in `proto2rest` when converting
`storage_pb2.ObjectAccessControl` to their REST representation.  Needed
some light refactoring in the `proto2rest` module to make this work.

Part of the work for #338 