### PR TITLE
feat: improve `DefaultObjectAccessControl: *` responses

### DIFF
--- a/testbench/proto2rest.py
+++ b/testbench/proto2rest.py
@@ -288,3 +288,10 @@ def object_access_control_as_rest(
 ):
     rest = json_format.MessageToDict(metadata)
     return __postprocess_object_access_control(bucket_id, object_id, generation, rest)
+
+
+def default_object_access_control_as_rest(
+    bucket_id: str, acl: storage_pb2.ObjectAccessControl
+):
+    rest = json_format.MessageToDict(acl)
+    return __postprocess_rest_default_object_acl(bucket_id, rest)

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -337,11 +337,13 @@ def bucket_acl_delete(bucket_name, entity):
 @retry_test(method="storage.default_object_acl.list")
 def bucket_default_object_acl_list(bucket_name):
     bucket = db.get_bucket(bucket_name, None)
-    response = {"kind": "storage#objectAccessControls", "items": []}
-    for acl in bucket.metadata.default_object_acl:
-        acl_rest = json_format.MessageToDict(acl)
-        acl_rest["kind"] = "storage#objectAccessControl"
-        response["items"].append(acl_rest)
+    response = {
+        "kind": "storage#objectAccessControls",
+        "items": [
+            testbench.proto2rest.default_object_access_control_as_rest(bucket_name, acl)
+            for acl in bucket.metadata.default_object_acl
+        ],
+    }
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(response, None, fields)
 
@@ -351,8 +353,9 @@ def bucket_default_object_acl_list(bucket_name):
 def bucket_default_object_acl_insert(bucket_name):
     bucket = db.get_bucket(bucket_name, None)
     acl = bucket.insert_default_object_acl(flask.request, None)
-    response = json_format.MessageToDict(acl)
-    response["kind"] = "storage#objectAccessControl"
+    response = testbench.proto2rest.default_object_access_control_as_rest(
+        bucket_name, acl
+    )
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(response, None, fields)
 
@@ -362,8 +365,9 @@ def bucket_default_object_acl_insert(bucket_name):
 def bucket_default_object_acl_get(bucket_name, entity):
     bucket = db.get_bucket(bucket_name, None)
     acl = bucket.get_default_object_acl(entity, None)
-    response = json_format.MessageToDict(acl)
-    response["kind"] = "storage#objectAccessControl"
+    response = testbench.proto2rest.default_object_access_control_as_rest(
+        bucket_name, acl
+    )
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(response, None, fields)
 
@@ -373,8 +377,9 @@ def bucket_default_object_acl_get(bucket_name, entity):
 def bucket_default_object_acl_update(bucket_name, entity):
     bucket = db.get_bucket(bucket_name, None)
     acl = bucket.update_default_object_acl(flask.request, entity, None)
-    response = json_format.MessageToDict(acl)
-    response["kind"] = "storage#objectAccessControl"
+    response = testbench.proto2rest.default_object_access_control_as_rest(
+        bucket_name, acl
+    )
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(response, None, fields)
 
@@ -385,8 +390,9 @@ def bucket_default_object_acl_patch(bucket_name, entity):
     testbench.common.enforce_patch_override(flask.request)
     bucket = db.get_bucket(bucket_name, None)
     acl = bucket.patch_default_object_acl(flask.request, entity, None)
-    response = json_format.MessageToDict(acl)
-    response["kind"] = "storage#objectAccessControl"
+    response = testbench.proto2rest.default_object_access_control_as_rest(
+        bucket_name, acl
+    )
     fields = flask.request.args.get("fields", None)
     return testbench.common.filter_response_rest(response, None, fields)
 
@@ -396,7 +402,7 @@ def bucket_default_object_acl_patch(bucket_name, entity):
 def bucket_default_object_acl_delete(bucket_name, entity):
     bucket = db.get_bucket(bucket_name, None)
     bucket.delete_default_object_acl(entity, None)
-    return ""
+    return flask.make_response("")
 
 
 @gcs.route("/b/<bucket_name>/notificationConfigs")

--- a/tests/test_proto2rest.py
+++ b/tests/test_proto2rest.py
@@ -52,6 +52,34 @@ class TestProto2Rest(unittest.TestCase):
         self.assertEqual(actual, {**actual, **expected})
         self.assertIn("etag", actual)
 
+    def test_default_object_access_control_as_rest(self):
+        acl = storage_pb2.ObjectAccessControl(
+            id="test-id",
+            entity="test-entity",
+            entity_id="test-entity-id",
+            role="test-role",
+            email="test-email",
+            domain="test-domain",
+            project_team=storage_pb2.ProjectTeam(
+                project_number="12345", team="test-team"
+            ),
+        )
+        actual = testbench.proto2rest.default_object_access_control_as_rest(
+            "test-bucket-id", acl
+        )
+        expected = {
+            "kind": "storage#objectAccessControl",
+            "id": "test-id",
+            "bucket": "test-bucket-id",
+            "entity": "test-entity",
+            "role": "test-role",
+            "email": "test-email",
+            "domain": "test-domain",
+            "projectTeam": {"projectNumber": "12345", "team": "test-team"},
+        }
+        self.assertEqual(actual, {**actual, **expected})
+        self.assertIn("etag", actual)
+
     def test_object_as_rest(self):
         media = b"The quick brown fox jumps over the lazy dog"
         # These checksums can be obtained using `gsutil hash`

--- a/tests/test_testbench_bucket.py
+++ b/tests/test_testbench_bucket.py
@@ -118,6 +118,10 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+        additional_fields = {
+            "kind": "storage#bucketAccessControl",
+            "bucket": "bucket-name",
+        }
         insert_data = {"entity": "allAuthenticatedUsers", "role": "READER"}
         response = self.client.post(
             "/storage/v1/b/bucket-name/acl", data=json.dumps(insert_data)
@@ -128,9 +132,8 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         insert_rest = json.loads(response.data)
         self.assertEqual(insert_rest, {**insert_rest, **insert_data})
+        self.assertEqual(insert_rest, {**insert_rest, **additional_fields})
         self.assertIn("etag", insert_rest)
-        self.assertIn("bucket", insert_rest)
-        self.assertIn("kind", insert_rest)
 
         response = self.client.get(
             "/storage/v1/b/bucket-name/acl/allAuthenticatedUsers"
@@ -141,9 +144,8 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         get_rest = json.loads(response.data)
         self.assertEqual(get_rest, insert_rest)
+        self.assertEqual(get_rest, {**get_rest, **additional_fields})
         self.assertIn("etag", get_rest)
-        self.assertIn("bucket", get_rest)
-        self.assertIn("kind", get_rest)
 
         response = self.client.patch(
             "/storage/v1/b/bucket-name/acl/allAuthenticatedUsers",
@@ -155,9 +157,8 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         patch_rest = json.loads(response.data)
         self.assertEqual(patch_rest.get("role", None), "OWNER")
+        self.assertEqual(patch_rest, {**patch_rest, **additional_fields})
         self.assertIn("etag", patch_rest)
-        self.assertIn("bucket", patch_rest)
-        self.assertIn("kind", patch_rest)
 
         update_data = patch_rest.copy()
         update_data["role"] = "READER"
@@ -171,9 +172,8 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         update_rest = json.loads(response.data)
         self.assertEqual(update_rest.get("role", None), "READER")
+        self.assertEqual(update_rest, {**update_rest, **additional_fields})
         self.assertIn("etag", update_rest)
-        self.assertIn("bucket", update_rest)
-        self.assertIn("kind", update_rest)
 
         response = self.client.get("/storage/v1/b/bucket-name/acl")
         self.assertEqual(response.status_code, 200)
@@ -186,9 +186,8 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         self.assertNotEqual(len(list_rest.get("items")), 0)
         front = list_rest.get("items")[0]
+        self.assertEqual(front, {**front, **additional_fields})
         self.assertIn("etag", front)
-        self.assertIn("bucket", front)
-        self.assertIn("kind", front)
 
         response = self.client.delete(
             "/storage/v1/b/bucket-name/acl/allAuthenticatedUsers"
@@ -206,6 +205,10 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+        additional_fields = {
+            "kind": "storage#objectAccessControl",
+            "bucket": "bucket-name",
+        }
         insert_data = {"entity": "allAuthenticatedUsers", "role": "READER"}
         response = self.client.post(
             "/storage/v1/b/bucket-name/defaultObjectAcl", data=json.dumps(insert_data)
@@ -216,6 +219,8 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         insert_rest = json.loads(response.data)
         self.assertEqual(insert_rest, {**insert_rest, **insert_data})
+        self.assertEqual(insert_rest, {**insert_rest, **additional_fields})
+        self.assertIn("etag", insert_rest)
 
         response = self.client.get(
             "/storage/v1/b/bucket-name/defaultObjectAcl/allAuthenticatedUsers"
@@ -226,6 +231,8 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         get_rest = json.loads(response.data)
         self.assertEqual(get_rest, insert_rest)
+        self.assertEqual(get_rest, {**get_rest, **additional_fields})
+        self.assertIn("etag", get_rest)
 
         response = self.client.patch(
             "/storage/v1/b/bucket-name/defaultObjectAcl/allAuthenticatedUsers",
@@ -237,6 +244,8 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         patch_rest = json.loads(response.data)
         self.assertEqual(patch_rest.get("role", None), "OWNER")
+        self.assertEqual(patch_rest, {**patch_rest, **additional_fields})
+        self.assertIn("etag", patch_rest)
 
         update_data = patch_rest.copy()
         update_data["role"] = "READER"
@@ -250,6 +259,8 @@ class TestTestbenchBucket(unittest.TestCase):
         )
         update_rest = json.loads(response.data)
         self.assertEqual(update_rest.get("role", None), "READER")
+        self.assertEqual(update_rest, {**update_rest, **additional_fields})
+        self.assertIn("etag", update_rest)
 
         response = self.client.get("/storage/v1/b/bucket-name/defaultObjectAcl")
         self.assertEqual(response.status_code, 200)
@@ -260,6 +271,9 @@ class TestTestbenchBucket(unittest.TestCase):
         self.assertIn(
             "allAuthenticatedUsers", [a.get("entity") for a in list_rest.get("items")]
         )
+        front = list_rest.get("items")[0]
+        self.assertEqual(update_rest, {**update_rest, **additional_fields})
+        self.assertIn("etag", update_rest)
 
         response = self.client.delete(
             "/storage/v1/b/bucket-name/defaultObjectAcl/allAuthenticatedUsers"


### PR DESCRIPTION
Just like for bucket and object access controls, we need to enrich the
responses for `DefaultObjectAccessControl: *`.  I also made the testing
more consistent across all three resources.

Fixes #338 