### PR TITLE
fix: predefinedACL replaces existing ACL in object patch/update

### DIFF
--- a/gcs/object.py
+++ b/gcs/object.py
@@ -222,13 +222,13 @@ class Object:
         metadata = json_format.ParseDict(
             testbench.common.preprocess_object_metadata(data), storage_pb2.Object()
         )
-        self.__update_metadata(metadata, None)
         self.__insert_predefined_acl(
             metadata,
             self.bucket,
             testbench.acl.extract_predefined_acl(request, False, context),
             context,
         )
+        self.__update_metadata(metadata, None)
 
     def patch(self, request, context):
         # Support for `Object: patch` over gRPC is not needed (and not implemented).
@@ -242,13 +242,13 @@ class Object:
             )
         )
         metadata = json_format.ParseDict(rest, storage_pb2.Object())
-        self.__update_metadata(metadata, None)
         self.__insert_predefined_acl(
             metadata,
             self.bucket,
             testbench.acl.extract_predefined_acl(request, False, context),
             context,
         )
+        self.__update_metadata(metadata, None)
 
     # === ACL === #
 

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -510,7 +510,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         if "metadata" in request.update_mask.paths:
             blob.metadata.metadata.clear()
             blob.metadata.metadata.update(request.object.metadata)
-        # Manually handle PredefinedACL.
+        # Manually handle predefinedACL.
         if request.predefined_acl is not None:
             acls = testbench.acl.compute_predefined_object_acl(
                 request.object.bucket,

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -510,6 +510,17 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         if "metadata" in request.update_mask.paths:
             blob.metadata.metadata.clear()
             blob.metadata.metadata.update(request.object.metadata)
+        # Manually handle PredefinedACL.
+        if request.predefined_acl is not None:
+            acls = testbench.acl.compute_predefined_object_acl(
+                request.object.bucket,
+                request.object.name,
+                request.object.generation,
+                request.predefined_acl,
+                context,
+            )
+            del blob.metadata.acl[:]
+            blob.metadata.acl.extend(acls)
         blob.metadata.metageneration += 1
         blob.metadata.update_time.FromDatetime(datetime.datetime.now())
         return blob.metadata


### PR DESCRIPTION
Fixes #351

PredefinedACL replaces the existing object ACL in `gRPC.UpdateObject`, `object.update` and `object.patch` operations

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR