### PR TITLE
fix: handle camel case in notifications ops

### DIFF
--- a/gcs/bucket.py
+++ b/gcs/bucket.py
@@ -528,6 +528,7 @@ class Bucket:
             "id": "notification-%s" % uuid.uuid4().hex,
         }
         data = json.loads(notification_rest)
+        data = {testbench.common.to_snake_case(k): v for k, v in data.items()}
         for required_key in {"topic", "payload_format"}:
             value = data.pop(required_key, None)
             if value is not None:


### PR DESCRIPTION
Convert camelCase (used with gRPC) to snakecase so required fields are captured in Notification operations

i.e. `PayloadFormat` to `payload_format`