### PR TITLE
fix: use 0.0.0.0 with gRPC

### DIFF
--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -694,6 +694,6 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
 def run(port, database):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     storage_pb2_grpc.add_StorageServicer_to_server(StorageServicer(database), server)
-    port = server.add_insecure_port("localhost:%d" % port)
+    port = server.add_insecure_port("0.0.0.0:%d" % port)
     server.start()
     return port, server


### PR DESCRIPTION
Use `0.0.0.0` when starting gRPC Server to unblock docker image usage.