### PR TITLE
fix: support gzip decompression on metadata requests

### DIFF
--- a/testbench/common.py
+++ b/testbench/common.py
@@ -16,6 +16,8 @@
 
 import base64
 from functools import wraps
+import gzip
+import io
 import json
 import random
 import re
@@ -799,6 +801,13 @@ def gen_retry_test_decorator(db):
         return decorator
 
     return retry_test
+
+
+def handle_gzip_request(request):
+    """Handle gzip compressed JSON payloads when Content-Encoding: gzip is present on metadata requests."""
+    if request.headers.get("Content-Encoding", "") == "gzip":
+        request.data = gzip.decompress(request.data)
+        request.environ["wsgi.input"] = io.BytesIO(request.data)
 
 
 def rest_crc32c_to_proto(crc32c):

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -804,8 +804,14 @@ def gen_retry_test_decorator(db):
 
 
 def handle_gzip_request(request):
-    """Handle gzip compressed JSON payloads when Content-Encoding: gzip is present on metadata requests."""
-    if request.headers.get("Content-Encoding", "") == "gzip":
+    """
+    Handle gzip compressed JSON payloads when Content-Encoding: gzip is present on metadata requests.
+    No decompressions for media uploads when object's metadata includes Content-Encoding: gzip.
+    """
+    if (
+        request.headers.get("Content-Encoding", None) == "gzip"
+        and request.args.get("contentEncoding", None) != "gzip"
+    ):
         request.data = gzip.decompress(request.data)
         request.environ["wsgi.input"] = io.BytesIO(request.data)
 

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -182,6 +182,11 @@ gcs.debug = False
 gcs.register_error_handler(Exception, testbench.error.RestException.handler)
 
 
+@gcs.before_request
+def handle_gzip_compressed_request():
+    return testbench.common.handle_gzip_request(flask.request)
+
+
 # === BUCKET === #
 
 

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -893,6 +893,11 @@ upload.debug = False
 upload.register_error_handler(Exception, testbench.error.RestException.handler)
 
 
+@upload.before_request
+def handle_gzip_compressed_request():
+    return testbench.common.handle_gzip_request(flask.request)
+
+
 @upload.route("/b/<bucket_name>/o", methods=["POST"])
 @retry_test(method="storage.objects.insert")
 def object_insert(bucket_name):

--- a/testbench/servers/iam_rest_server.py
+++ b/testbench/servers/iam_rest_server.py
@@ -28,6 +28,11 @@ _iam.debug = False
 _iam.register_error_handler(Exception, testbench.error.RestException.handler)
 
 
+@_iam.before_request
+def handle_gzip_compressed_request():
+    return testbench.common.handle_gzip_request(flask.request)
+
+
 @_iam.route("/projects/-/serviceAccounts/<service_account>:signBlob", methods=["POST"])
 def sign_blob(service_account):
     """Implement the `projects.serviceAccounts.signBlob` API."""

--- a/testbench/servers/projects_rest_server.py
+++ b/testbench/servers/projects_rest_server.py
@@ -30,6 +30,10 @@ def get_projects_app(db):
     projects.debug = False
     projects.register_error_handler(Exception, testbench.error.RestException.handler)
 
+    @projects.before_request
+    def handle_gzip_compressed_request():
+        return testbench.common.handle_gzip_request(flask.request)
+
     @projects.route("/<project_id>/serviceAccount")
     @retry_test("storage.serviceaccount.get")
     def projects_get(project_id):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -17,6 +17,7 @@
 """Unit test for utils"""
 
 import base64
+import gzip
 import hashlib
 import json
 import types
@@ -1204,6 +1205,27 @@ class TestCommonUtils(unittest.TestCase):
                 testbench.common.bucket_name_to_proto("bucket.example.com")
             ),
         )
+
+    def test_handle_gzip_request(self):
+        # Test gzip decompresses request payload when Content-Encoding: gzip is present
+        payload = b'{"name": "bucket-name"}'
+        compressed = gzip.compress(payload)
+        request = testbench.common.FakeRequest(
+            headers={"Content-Encoding": "gzip"},
+            data=compressed,
+            environ={},
+        )
+        testbench.common.handle_gzip_request(request)
+        self.assertEqual(request.data, payload)
+
+        # Test no ops when Content-Encoding: gzip is not present
+        request = testbench.common.FakeRequest(
+            headers={},
+            data=payload,
+            environ={},
+        )
+        testbench.common.handle_gzip_request(request)
+        self.assertEqual(request.data, payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #379 

Adds gzip decompression support using the [`before_request` decorator](https://flask.palletsprojects.com/en/2.1.x/api/#flask.Flask.before_request)
- **adds** gzip decompression when `Content-Encoding: "gzip"` is present in request headers
- **no** decompression when object's metadata includes `contentEncoding: "gzip"` in upload requests so that we can store data compressed when applicable and preserve decompressive transcoding improvements made in #322