### PR TITLE
feat: support status codes 206 and 416 for range downloads

### DIFF
--- a/gcs/object.py
+++ b/gcs/object.py
@@ -376,6 +376,10 @@ class Object:
         begin, end, length, response_payload = self._download_range(
             request, response_payload
         )
+        # Return 416 if the requested range cannot be satisfied.
+        if range_header is not None and begin >= length:
+            testbench.error.range_not_satisfiable()
+
         headers = {}
         content_range = "bytes %d-%d/%d" % (begin, end - 1, length)
 

--- a/gcs/object.py
+++ b/gcs/object.py
@@ -372,6 +372,7 @@ class Object:
             if self._decompress_on_download(request)
             else self.media
         )
+        range_header = request.headers.get("range")
         begin, end, length, response_payload = self._download_range(
             request, response_payload
         )
@@ -488,4 +489,9 @@ class Object:
         headers["x-goog-generation"] = self.metadata.generation
         headers["x-goog-metageneration"] = self.metadata.metageneration
         headers["x-goog-storage-class"] = self.metadata.storage_class
+
+        # Return status code 206 if a valid range request header is included.
+        if range_header and not self._decompress_on_download(request):
+            return flask.Response(streamer(), status=206, headers=headers)
+
         return flask.Response(streamer(), status=200, headers=headers)

--- a/testbench/error.py
+++ b/testbench/error.py
@@ -139,3 +139,15 @@ def already_exists(context=None):
         grpc_code=grpc.StatusCode.ALREADY_EXISTS,
         context=context,
     )
+
+
+def range_not_satisfiable(
+    context=None, rest_code=416, grpc_code=grpc.StatusCode.OUT_OF_RANGE
+):
+    """Error returned when request range is not satisfiable."""
+    generic(
+        _simple_json_error("request range not satisfiable"),
+        rest_code,
+        grpc_code,
+        context,
+    )

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -681,7 +681,7 @@ class TestObject(unittest.TestCase):
                 )
             )
             response = blob.rest_media(request)
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 206)
             self.assertEqual(response.data, expected)
             self.assertIn("content-range", response.headers)
             content_range = response.headers["content-range"]

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -689,6 +689,17 @@ class TestObject(unittest.TestCase):
                 content_range.endswith("/%d" % len(blob.media)),
                 msg="unexpected content-range header: " + content_range,
             )
+        # Test raises 416 if request range cannot be satisfied.
+        request = Request(
+            create_environ(
+                base_url="http://localhost:8080",
+                headers={"range": "bytes=36-"},
+                data=json.dumps({}),
+            )
+        )
+        with self.assertRaises(testbench.error.RestException) as rest:
+            response = blob.rest_media(request)
+        self.assertEqual(rest.exception.code, 416)
 
     def test_rest_media_instructions(self):
         boundary, payload = format_multipart_upload(


### PR DESCRIPTION
This adds validation to range download request headers
- testbench returns `206 Partial Content` for valid range download requests
- testbench returns `416 Requested Range Not Satisfiable` for invalid range headers

Fixes #396 and some of #331


- [x] Tests pass