### PR TITLE
feat: support gRPC metadata echo

### DIFF
--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -98,28 +98,46 @@ def _logging_method_decorator(function):
 
     return decorated
 
+def _metadata_echo_decorator(function):
+    """
+    Send back the invocation metadata as initial metadata, if metadata echo is
+    enabled.
+    """
 
-def log_all_rpc_methods(klass):
+    @functools.wraps(function)
+    def decorated(self, request, context):
+        if self.echo_metadata:
+            req_metadata = context.invocation_metadata()
+            resp_metadata = list(map(lambda md: ('x-req-'+md[0], md[1]), req_metadata))
+            context.send_initial_metadata(resp_metadata)
+        return function(self, request, context)
+
+    return decorated
+
+
+def decorate_all_rpc_methods(klass):
     """Decorate all the RPC-looking methods."""
     for key in dir(klass):
         if key.startswith("_"):
             continue
         value = getattr(klass, key)
         if isinstance(value, types.FunctionType):
-            wrapped = _logging_method_decorator(value)
+            wrapped = _metadata_echo_decorator(value)
+            wrapped = _logging_method_decorator(wrapped)
             setattr(klass, key, wrapped)
     return klass
 
 
 # Keep the methods in this class in the same order as the RPCs in storage.proto.
 # That makes it easier to find them later.
-@log_all_rpc_methods
+@decorate_all_rpc_methods
 class StorageServicer(storage_pb2_grpc.StorageServicer):
     """Implements the google.storage.v2.Storage gRPC service."""
 
-    def __init__(self, db):
+    def __init__(self, db, echo_metadata=False):
         self.db = db
         self.db.insert_test_bucket()
+        self.echo_metadata = echo_metadata
 
     def DeleteBucket(self, request, context):
         self.db.delete_bucket(
@@ -752,9 +770,11 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         return self._hmac_key_metadata_from_rest(rest)
 
 
-def run(port, database):
+def run(port, database, echo_metadata=False):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
-    storage_pb2_grpc.add_StorageServicer_to_server(StorageServicer(database), server)
+    storage_pb2_grpc.add_StorageServicer_to_server(
+        StorageServicer(database, echo_metadata),
+        server)
     port = server.add_insecure_port("0.0.0.0:%d" % port)
     server.start()
     return port, server

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -98,6 +98,7 @@ def _logging_method_decorator(function):
 
     return decorated
 
+
 def _metadata_echo_decorator(function):
     """
     Send back the invocation metadata as initial metadata, if metadata echo is
@@ -108,7 +109,9 @@ def _metadata_echo_decorator(function):
     def decorated(self, request, context):
         if self.echo_metadata:
             req_metadata = context.invocation_metadata()
-            resp_metadata = list(map(lambda md: ('x-req-'+md[0], md[1]), req_metadata))
+            resp_metadata = list(
+                map(lambda md: ("x-req-" + md[0], md[1]), req_metadata)
+            )
             context.send_initial_metadata(resp_metadata)
         return function(self, request, context)
 
@@ -773,8 +776,8 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
 def run(port, database, echo_metadata=False):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     storage_pb2_grpc.add_StorageServicer_to_server(
-        StorageServicer(database, echo_metadata),
-        server)
+        StorageServicer(database, echo_metadata), server
+    )
     port = server.add_insecure_port("0.0.0.0:%d" % port)
     server.start()
     return port, server

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -171,7 +171,11 @@ def start_grpc():
     global db
     if grpc_port == 0:
         port = flask.request.args.get("port", "0")
-        grpc_port, grpc_service = testbench.grpc_server.run(int(port), db)
+        echo_metadata = flask.request.args.get("echo-metadata", False)
+        grpc_port, grpc_service = testbench.grpc_server.run(
+                                    int(port),
+                                    db, 
+                                    echo_metadata=echo_metadata)
     return str(grpc_port)
 
 

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -173,9 +173,8 @@ def start_grpc():
         port = flask.request.args.get("port", "0")
         echo_metadata = flask.request.args.get("echo-metadata", False)
         grpc_port, grpc_service = testbench.grpc_server.run(
-                                    int(port),
-                                    db, 
-                                    echo_metadata=echo_metadata)
+            int(port), db, echo_metadata=echo_metadata
+        )
     return str(grpc_port)
 
 

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1729,8 +1729,8 @@ class TestGrpc(unittest.TestCase):
             grpc.insecure_channel("localhost:%d" % port)
         )
         request = storage_pb2.GetBucketRequest(name="projects/_/buckets/bucket-name")
-        response, call = stub.GetBucket.with_call(request, metadata=(('hdr1', 'foo'),))
-        self.assertIn(('x-req-hdr1', 'foo'), call.initial_metadata())
+        response, call = stub.GetBucket.with_call(request, metadata=(("hdr1", "foo"),))
+        self.assertIn(("x-req-hdr1", "foo"), call.initial_metadata())
         server.stop(grace=0)
 
 

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1720,6 +1720,19 @@ class TestGrpc(unittest.TestCase):
         self.assertNotEqual(start.upload_id, "")
         server.stop(grace=0)
 
+    def test_echo_metadata(self):
+        port, server = testbench.grpc_server.run(0, self.db, echo_metadata=True)
+        self.assertNotEqual(port, 0)
+        self.assertIsNotNone(server)
+
+        stub = storage_pb2_grpc.StorageStub(
+            grpc.insecure_channel("localhost:%d" % port)
+        )
+        request = storage_pb2.GetBucketRequest(name="projects/_/buckets/bucket-name")
+        response, call = stub.GetBucket.with_call(request, metadata=(('hdr1', 'foo'),))
+        self.assertIn(('x-req-hdr1', 'foo'), call.initial_metadata())
+        server.stop(grace=0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
gRPC server can now optionally echo request metadata for all RPC methods. Echoed headers are prefixed with 'x-req-'. The feature is controlled via an 'echo-metadata' query parameter to '/start_grpc'.