### PR TITLE
feat: support request header X-Guploader-No-308

### DIFF
--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -241,13 +241,13 @@ class Upload(types.SimpleNamespace):
             upload.metadata.metadata["x_emulator_no_md5"] = "true"
         return upload, is_resumable
 
-    def resumable_status_rest(self, no_308=False):
+    def resumable_status_rest(self, override_308=False):
         response = flask.make_response()
         if len(self.media) > 1 and not self.complete:
             response.headers["Range"] = "bytes=0-%d" % (len(self.media) - 1)
         response.status_code = 308
 
-        if no_308:
+        if override_308:
             response.headers["X-Http-Status-Code-Override"] = "308"
             response.status_code = 200
         return response

--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -241,9 +241,13 @@ class Upload(types.SimpleNamespace):
             upload.metadata.metadata["x_emulator_no_md5"] = "true"
         return upload, is_resumable
 
-    def resumable_status_rest(self):
+    def resumable_status_rest(self, no_308=False):
         response = flask.make_response()
         if len(self.media) > 1 and not self.complete:
             response.headers["Range"] = "bytes=0-%d" % (len(self.media) - 1)
         response.status_code = 308
+
+        if no_308:
+            response.headers["X-Http-Status-Code-Override"] = "308"
+            response.status_code = 200
         return response

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -901,9 +901,15 @@ def handle_gzip_compressed_request():
 @upload.route("/b/<bucket_name>/o", methods=["POST"])
 @retry_test(method="storage.objects.insert")
 def object_insert(bucket_name):
+    # GCS supports "POST" calls for uploading data with an upload_id
+    request = flask.request
+    upload_id = request.args.get("upload_id")
+    if upload_id is not None:
+        return resumable_upload_chunk(bucket_name)
+
     db.insert_test_bucket()
     bucket = db.get_bucket(bucket_name, None).metadata
-    upload_type = flask.request.args.get("uploadType")
+    upload_type = request.args.get("uploadType")
     if upload_type is None:
         testbench.error.missing("uploadType", None)
     elif upload_type not in {"multipart", "media", "resumable"}:
@@ -1043,7 +1049,11 @@ def resumable_upload_chunk(bucket_name):
             blob.rest_metadata(), projection, fields
         )
     else:
-        return upload.resumable_status_rest()
+        # If request header "X-GUploader-No-308: yes" is included, instead of returning 308
+        # Resume Incomplete, return 200 with a response header X-HTTP-Status-Code-Override: 308
+        # See more at https://g3doc.corp.google.com/cloud/storage/g3doc/user/scotty/faq.md?cl=head
+        no_308 = request.headers.get("X-Guploader-No-308") == "yes"
+        return upload.resumable_status_rest(no_308=no_308)
 
 
 @upload.route("/b/<bucket_name>/o", methods=["DELETE"])

--- a/tests/test_testbench_object_upload.py
+++ b/tests/test_testbench_object_upload.py
@@ -152,6 +152,15 @@ class TestTestbenchObjectUpload(unittest.TestCase):
         self.assertEqual(response.status_code, 308)
         self.assertIn("range", response.headers)
 
+        response = self.client.put(
+            "/upload/storage/v1/b/bucket-name/o",
+            query_string={"upload_id": upload_id},
+            headers={
+                "X-Guploader-No-308": "yes",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
         response = self.client.delete(
             "/upload/storage/v1/b/bucket-name/o",
             query_string={"upload_id": upload_id},

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -264,6 +264,11 @@ class TestHolder(unittest.TestCase):
             self.assertEqual(status.status_code, 308)
             self.assertIn("Range", status.headers)
             self.assertEqual("bytes=0-42", status.headers.get("Range", None))
+            # Simulate a chunk upload that requests 200 status code instead of 308
+            upload.media = "How vexingly quick daft zebras jump"
+            status = upload.resumable_status_rest(no_308=True)
+            self.assertEqual(status.status_code, 200)
+            self.assertIn("X-Http-Status-Code-Override", status.headers)
 
     def test_init_object_write_grpc_non_resumable(self):
         line = b"The quick brown fox jumps over the lazy dog\n"

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -266,7 +266,7 @@ class TestHolder(unittest.TestCase):
             self.assertEqual("bytes=0-42", status.headers.get("Range", None))
             # Simulate a chunk upload that requests 200 status code instead of 308
             upload.media = "How vexingly quick daft zebras jump"
-            status = upload.resumable_status_rest(no_308=True)
+            status = upload.resumable_status_rest(override_308=True)
             self.assertEqual(status.status_code, 200)
             self.assertIn("X-Http-Status-Code-Override", status.headers)
 


### PR DESCRIPTION
Fixes #402

This adds support for `X-GUploader-No-308: yes`  - if included in resumable upload request headers, instead of returning 308: resume incomplete, [return 200 to satisfy the client and add a X-HTTP-Status-Code-Override: 308 response header](https://github.com/googleapis/storage-testbench/issues/go/scotty-faq#my-client-received-an-http-308-response-with-no-location-header)

- [x] Tests pass