### PR TITLE
feat: replace `gunicorn` with `uvicorn` to support Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,7 @@ COPY . /opt/storage-testbench/
 
 RUN python3 -m pip install -e .
 
-CMD ["gunicorn", \
-      "--bind", "0.0.0.0:9000", \
-      "--worker-class", "sync", \
-      "--threads", "10", \
-      "--access-logfile", "-", \
-      "testbench:run()"]
+CMD ["uvicorn", \
+      "testbench:run", \
+      "--host", "0.0.0.0", "--port", "9000", \
+      "--access-log"]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ It is useful as well to test features that are not yet deployed to production: y
 To start the testbench, run this command from a terminal:
 
 ```bash
-gunicorn --bind "localhost:9000" --worker-class sync --threads 10 --reload --access-logfile - "testbench:run()"
+uvicorn testbench:run --host localhost --port 9000 --reload --access-log
 ```
 
 > ⚠️ Ensure that the virtual environment you created to install the dependencies is active.

--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,7 @@ setuptools.setup(
         "scalpl==0.4.2",
         "crc32c==2.3",
         "gunicorn==20.1.0",
+        "uvicorn==0.18.3",
+        "asgiref==3.3.4",
     ],
 )

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -21,6 +21,7 @@ import flask
 from google.protobuf import json_format
 from werkzeug import serving
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from asgiref.wsgi import WsgiToAsgi
 
 from google.storage.v2 import storage_pb2
 import gcs as gcs_type
@@ -1089,6 +1090,8 @@ server.wsgi_app = DispatcherMiddleware(
         IAM_HANDLER_PATH: iam_app,
     },
 )
+
+server = WsgiToAsgi(server)
 
 
 def _run():

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -26,7 +26,7 @@ from testbench import rest_server
 
 class TestEcho(unittest.TestCase):
     def setUp(self):
-        self.client = rest_server.server.test_client()
+        self.client = rest_server.server.wsgi_application.test_client()
 
     def test_delete(self):
         expected_args = {"arg1": "value1", "arg2": "value2"}

--- a/tests/test_testbench_bucket.py
+++ b/tests/test_testbench_bucket.py
@@ -26,7 +26,7 @@ from testbench import rest_server
 class TestTestbenchBucket(unittest.TestCase):
     def setUp(self):
         rest_server.db.clear()
-        self.client = rest_server.server.test_client()
+        self.client = rest_server.server.wsgi_application.test_client()
         # Avoid magic buckets in the test
         os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
 

--- a/tests/test_testbench_object_gzip.py
+++ b/tests/test_testbench_object_gzip.py
@@ -32,11 +32,15 @@ UPLOAD_QUANTUM = 256 * 1024
 class TestTestbenchObjectGzip(unittest.TestCase):
     def setUp(self):
         rest_server.db.clear()
-        rest_server.server.config["PREFERRED_URL_SCHEME"] = "https"
-        rest_server.server.config["SERVER_NAME"] = "storage.googleapis.com"
+        rest_server.server.wsgi_application.config["PREFERRED_URL_SCHEME"] = "https"
+        rest_server.server.wsgi_application.config[
+            "SERVER_NAME"
+        ] = "storage.googleapis.com"
         rest_server.root.config["PREFERRED_URL_SCHEME"] = "https"
         rest_server.root.config["SERVER_NAME"] = "storage.googleapis.com"
-        self.client = rest_server.server.test_client(allow_subdomain_redirects=True)
+        self.client = rest_server.server.wsgi_application.test_client(
+            allow_subdomain_redirects=True
+        )
         # Avoid magic buckets in the test
         os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
 

--- a/tests/test_testbench_object_metadata.py
+++ b/tests/test_testbench_object_metadata.py
@@ -27,7 +27,7 @@ from testbench import rest_server
 class TestTestbenchObjectMetadata(unittest.TestCase):
     def setUp(self):
         rest_server.db.clear()
-        self.client = rest_server.server.test_client()
+        self.client = rest_server.server.wsgi_application.test_client()
         # Avoid magic buckets in the test
         os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
 

--- a/tests/test_testbench_object_special.py
+++ b/tests/test_testbench_object_special.py
@@ -26,7 +26,7 @@ from testbench import rest_server
 class TestTestbenchObjectSpecial(unittest.TestCase):
     def setUp(self):
         rest_server.db.clear()
-        self.client = rest_server.server.test_client()
+        self.client = rest_server.server.wsgi_application.test_client()
         # Avoid magic buckets in the test
         os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
 

--- a/tests/test_testbench_object_upload.py
+++ b/tests/test_testbench_object_upload.py
@@ -31,7 +31,7 @@ UPLOAD_QUANTUM = 256 * 1024
 class TestTestbenchObjectUpload(unittest.TestCase):
     def setUp(self):
         rest_server.db.clear()
-        self.client = rest_server.server.test_client()
+        self.client = rest_server.server.wsgi_application.test_client()
         # Avoid magic buckets in the test
         os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
 

--- a/tests/test_testbench_object_xml.py
+++ b/tests/test_testbench_object_xml.py
@@ -26,11 +26,15 @@ from testbench import rest_server
 class TestTestbenchObjectXML(unittest.TestCase):
     def setUp(self):
         rest_server.db.clear()
-        rest_server.server.config["PREFERRED_URL_SCHEME"] = "https"
-        rest_server.server.config["SERVER_NAME"] = "storage.googleapis.com"
+        rest_server.server.wsgi_application.config["PREFERRED_URL_SCHEME"] = "https"
+        rest_server.server.wsgi_application.config[
+            "SERVER_NAME"
+        ] = "storage.googleapis.com"
         rest_server.root.config["PREFERRED_URL_SCHEME"] = "https"
         rest_server.root.config["SERVER_NAME"] = "storage.googleapis.com"
-        self.client = rest_server.server.test_client(allow_subdomain_redirects=True)
+        self.client = rest_server.server.wsgi_application.test_client(
+            allow_subdomain_redirects=True
+        )
         # Avoid magic buckets in the test
         os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
 

--- a/tests/test_testbench_retry.py
+++ b/tests/test_testbench_retry.py
@@ -31,7 +31,7 @@ UPLOAD_QUANTUM = 256 * 1024
 class TestTestbenchRetry(unittest.TestCase):
     def setUp(self):
         rest_server.db.clear()
-        self.client = rest_server.server.test_client()
+        self.client = rest_server.server.wsgi_application.test_client()
         # Avoid magic buckets in the test
         os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
 

--- a/tests/test_testbench_root.py
+++ b/tests/test_testbench_root.py
@@ -25,7 +25,7 @@ from testbench import rest_server
 class TestTestbenchRoot(unittest.TestCase):
     def setUp(self):
         rest_server.db.clear()
-        self.client = rest_server.server.test_client()
+        self.client = rest_server.server.wsgi_application.test_client()
         # Avoid magic buckets in the test
         os.environ.pop("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", None)
 

--- a/tests/test_testbench_startup.py
+++ b/tests/test_testbench_startup.py
@@ -30,15 +30,13 @@ from google.storage.v2 import storage_pb2, storage_pb2_grpc
 
 class TestTestbenchStartup(unittest.TestCase):
     def setUp(self):
-        self.gunicorn = subprocess.Popen(
+        self.uvicorn = subprocess.Popen(
             [
-                "gunicorn",
-                "--bind=localhost:0",
-                "--worker-class=sync",
-                "--threads=2",
+                "uvicorn",
+                "testbench:run",
+                "--host=localhost",
                 "--reload",
-                "--access-logfile=-",
-                "testbench:run()",
+                "--access-log",
             ],
             stderr=subprocess.PIPE,
             stdout=None,
@@ -59,36 +57,36 @@ class TestTestbenchStartup(unittest.TestCase):
         )
 
     def tearDown(self):
-        processes = [self.gunicorn, self.plain]
+        processes = [self.uvicorn, self.plain]
         for p in processes:
             p.stderr.close()
             p.kill()
             p.wait(30)
 
-    def wait_gunicorn(self):
+    def wait_uvicorn(self):
         started = False
         port = None
         start = time.time()
         # Wait for the message declaring this process is running
         while not started and time.time() - start < 120:
-            line = self.gunicorn.stderr.readline()
-            if "Listening at: http://" in line:
-                m = re.compile("Listening at:.*:([0-9]+) ").search(line)
+            line = self.uvicorn.stderr.readline()
+            if "Uvicorn running on http://" in line:
+                m = re.compile("Uvicorn running on.*:([0-9]+) ").search(line)
                 if m is not None:
                     started = True
                     port = m[1]
         self.assertTrue(started)
         return port
 
-    def test_startup_gunicorn(self):
-        port = self.wait_gunicorn()
+    def test_startup_uvicorn(self):
+        port = self.wait_uvicorn()
         self.assertIsNotNone(port)
         response = requests.get("http://localhost:" + port)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, "OK")
 
-    def test_startup_gunicorn_grpc(self):
-        port = self.wait_gunicorn()
+    def test_startup_uvicorn_grpc(self):
+        port = self.wait_uvicorn()
         self.assertIsNotNone(port)
         response = requests.post(
             "http://localhost:%s/storage/v1/b?project=test-only" % port,


### PR DESCRIPTION
This PR contains changes which will make storage test bench windows compatible.
- Replaced gunicorn command with uvicorn to run the test bench. Uvicorn is windows compatible.
- Done changes to convert wsgi server into an asgi server as uvicorn needs asgi server.
- Updated corresponding python test files

- [x] Appropriate changes to README are included in PR