### PR TITLE
feat: use `entity_alt` in `*AccessControl`

### DIFF
--- a/testbench/proto2rest.py
+++ b/testbench/proto2rest.py
@@ -121,6 +121,7 @@ def __postprocess_rest_bucket_acl(bucket_id, acl):
     copy = acl.copy()
     copy["kind"] = "storage#bucketAccessControl"
     copy["bucket"] = bucket_id
+    copy.pop("entityAlt", None)
     return copy
 
 
@@ -128,6 +129,7 @@ def __postprocess_rest_default_object_acl(bucket_id, acl):
     copy = acl.copy()
     copy["kind"] = "storage#objectAccessControl"
     copy["bucket"] = bucket_id
+    copy.pop("entityAlt", None)
     return copy
 
 
@@ -186,6 +188,7 @@ def __postprocess_object_access_control(
     copy["bucket"] = bucket_id
     copy["object"] = object_id
     copy["generation"] = generation
+    copy.pop("entityAlt", None)
     return copy
 
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -31,6 +31,16 @@ class TestACL(unittest.TestCase):
         self.assertNotEqual(actual.id, "")
         self.assertNotEqual(actual.etag, "")
 
+    def test_create_bucket_with_alt(self):
+        actual = testbench.acl.create_bucket_acl(
+            "bucket-name", "project-owners-project-id", "OWNER", context=None
+        )
+        self.assertEqual(actual.entity_alt, "project-owners-project-id")
+        self.assertEqual(actual.role, "OWNER")
+        self.assertEqual(actual.entity, testbench.acl.get_project_entity("owners", None))
+        self.assertNotEqual(actual.id, "")
+        self.assertNotEqual(actual.etag, "")
+
     def test_create_default_object_acl(self):
         actual = testbench.acl.create_default_object_acl(
             "bucket-name", "test-entity", "READER", context=None
@@ -46,6 +56,16 @@ class TestACL(unittest.TestCase):
         )
         self.assertEqual(actual.role, "OWNER")
         self.assertEqual(actual.entity, "test-entity")
+        self.assertNotEqual(actual.id, "")
+        self.assertNotEqual(actual.etag, "")
+
+    def test_create_object_with_alt(self):
+        actual = testbench.acl.create_object_acl(
+            "bucket-name", "object-name", 123, "project-owners-project-id", "OWNER", context=None
+        )
+        self.assertEqual(actual.entity_alt, "project-owners-project-id")
+        self.assertEqual(actual.role, "OWNER")
+        self.assertEqual(actual.entity, testbench.acl.get_project_entity("owners", None))
         self.assertNotEqual(actual.id, "")
         self.assertNotEqual(actual.etag, "")
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -37,7 +37,9 @@ class TestACL(unittest.TestCase):
         )
         self.assertEqual(actual.entity_alt, "project-owners-project-id")
         self.assertEqual(actual.role, "OWNER")
-        self.assertEqual(actual.entity, testbench.acl.get_project_entity("owners", None))
+        self.assertEqual(
+            actual.entity, testbench.acl.get_project_entity("owners", None)
+        )
         self.assertNotEqual(actual.id, "")
         self.assertNotEqual(actual.etag, "")
 
@@ -61,11 +63,18 @@ class TestACL(unittest.TestCase):
 
     def test_create_object_with_alt(self):
         actual = testbench.acl.create_object_acl(
-            "bucket-name", "object-name", 123, "project-owners-project-id", "OWNER", context=None
+            "bucket-name",
+            "object-name",
+            123,
+            "project-owners-project-id",
+            "OWNER",
+            context=None,
         )
         self.assertEqual(actual.entity_alt, "project-owners-project-id")
         self.assertEqual(actual.role, "OWNER")
-        self.assertEqual(actual.entity, testbench.acl.get_project_entity("owners", None))
+        self.assertEqual(
+            actual.entity, testbench.acl.get_project_entity("owners", None)
+        )
         self.assertNotEqual(actual.id, "")
         self.assertNotEqual(actual.etag, "")
 

--- a/tests/test_proto2rest.py
+++ b/tests/test_proto2rest.py
@@ -28,6 +28,7 @@ class TestProto2Rest(unittest.TestCase):
         acl = storage_pb2.BucketAccessControl(
             id="test-id",
             entity="test-entity",
+            entity_alt="test-entity-alt",
             entity_id="test-entity-id",
             role="test-role",
             email="test-email",
@@ -57,6 +58,7 @@ class TestProto2Rest(unittest.TestCase):
         acl = storage_pb2.ObjectAccessControl(
             id="test-id",
             entity="test-entity",
+            entity_alt="test-entity-alt",
             entity_id="test-entity-id",
             role="test-role",
             email="test-email",
@@ -100,10 +102,16 @@ class TestProto2Rest(unittest.TestCase):
             cache_control="test-cache-control",
             acl=[
                 storage_pb2.ObjectAccessControl(
-                    entity="test-entity0", role="test-role0", etag="test-only-etag0"
+                    entity="test-entity0",
+                    entity_alt="test-entity0-alt",
+                    role="test-role0",
+                    etag="test-only-etag0",
                 ),
                 storage_pb2.ObjectAccessControl(
-                    entity="test-entity1", role="test-role1", etag="test-only-etag1"
+                    entity="test-entity1",
+                    entity_alt="test-entity1-alt",
+                    role="test-role1",
+                    etag="test-only-etag1",
                 ),
             ],
             content_language="test-content-language",
@@ -200,7 +208,10 @@ class TestProto2Rest(unittest.TestCase):
 
     def test_object_access_control_as_rest(self):
         input = storage_pb2.ObjectAccessControl(
-            entity="test-entity0", role="test-role0", etag="test-only-etag0"
+            entity="test-entity0",
+            entity_alt="test-entity0-alt",
+            role="test-role0",
+            etag="test-only-etag0",
         )
         expected = {
             "kind": "storage#objectAccessControl",


### PR DESCRIPTION
Some entities have two spellings.  gRPC will return both, allowing client libraries to implement *AccessControl operations using OCC loops.
