### PR TITLE
fix: Use the correct range in response header

### DIFF
--- a/gcs/object.py
+++ b/gcs/object.py
@@ -354,8 +354,8 @@ class Object:
             m = re.match("bytes=([0-9]+)-([0-9]+)", range_header)
             if m:
                 begin = int(m.group(1))
-                end = int(m.group(2))
-                response_payload = response_payload[begin : end + 1]
+                end = int(m.group(2)) + 1
+                response_payload = response_payload[begin : end]
             m = re.match("bytes=([0-9]+)-$", range_header)
             if m:
                 begin = int(m.group(1))

--- a/gcs/object.py
+++ b/gcs/object.py
@@ -355,7 +355,7 @@ class Object:
             if m:
                 begin = int(m.group(1))
                 end = int(m.group(2)) + 1
-                response_payload = response_payload[begin : end]
+                response_payload = response_payload[begin:end]
             m = re.match("bytes=([0-9]+)-$", range_header)
             if m:
                 begin = int(m.group(1))

--- a/gcs/object.py
+++ b/gcs/object.py
@@ -363,6 +363,7 @@ class Object:
             m = re.match("bytes=-([0-9]+)$", range_header)
             if m:
                 last = int(m.group(1))
+                begin = end - last
                 response_payload = response_payload[-last:]
         return begin, end, length, response_payload
 

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -670,7 +670,7 @@ class TestObject(unittest.TestCase):
         cases = {
             "bytes=4-9": (b"vexing", "4-9"),
             "bytes=12-": (b" quick daft zebras jump!", "12-35"),
-            "bytes=-5": (b"jump!", "0-35"),
+            "bytes=-5": (b"jump!", "31-35"),
         }
         for range, expected in cases.items():
             expected_data, expected_range = expected


### PR DESCRIPTION
Fixes https://github.com/googleapis/storage-testbench/issues/445

The end byte for the range header in the response is incorrect.  

Before:
```
 $ curl -v   'http://localhost:9000/storage/v1/b/test_bucket/o/hello.txt?alt=media' --header 'Range: bytes=0-2'   2>&1 | grep Content-Rang
e
< Content-Range: bytes 0-1/10
```

After:
```
$ curl -v   'http://localhost:9000/storage/v1/b/test_bucket/o/hello.txt?alt=media' --header 'Range: bytes=0-2'   2>&1 | grep Content-Range
< Content-Range: bytes 0-2/10
```

- [x] Tests pass
- [x] Appropriate changes to README are included in PR - N/A