### PR TITLE
ci: fix ignore list for code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,3 @@
 ignore:
-  - "google/iam/v1/**/*"
-  - "google/storage/v2/**/*"
+  - "google/iam"
+  - "google/storage"


### PR DESCRIPTION
The ignore list was plain wrong. With this change we ignore the generated files in `google/iam` and `google/storage`.
