### PR TITLE
feat(gRPC): validate both project fields

### DIFF
--- a/gcs/bucket.py
+++ b/gcs/bucket.py
@@ -316,7 +316,15 @@ class Bucket:
         cls.__validate_json_bucket_name(
             testbench.common.bucket_name_from_proto(request.bucket_id), context
         )
-        cls.__validate_grpc_project_name(request.parent, context)
+        if request.parent == "projects/_":
+            cls.__validate_grpc_project_name(request.bucket.project, context)
+        else:
+            cls.__validate_grpc_project_name(request.parent, context)
+            if request.bucket.project != "":
+                testbench.error.invalid(
+                    "CreateBucketRequest with invalid combination of `parent` and `bucket.project` fields",
+                    context,
+                )
         metadata = request.bucket
         cls._init_defaults(metadata, context)
         metadata.bucket_id = request.bucket_id

--- a/tests/test_bucket_grpc.py
+++ b/tests/test_bucket_grpc.py
@@ -26,8 +26,8 @@ import gcs
 
 
 class TestBucketGrpc(unittest.TestCase):
-    @classmethod
-    def _raise_grpc_error():
+    @staticmethod
+    def _raise_grpc_error(*args, **kwargs):
         raise Exception("grpc error")
 
     def test_init_grpc_simple(self):
@@ -39,12 +39,54 @@ class TestBucketGrpc(unittest.TestCase):
         context = unittest.mock.Mock()
         bucket, _ = gcs.bucket.Bucket.init_grpc(request, context)
         self.assertEqual(bucket.metadata.name, "projects/_/buckets/test-bucket-name")
+        self.assertTrue(
+            bucket.metadata.project.startswith("projects/"), msg=bucket.metadata.project
+        )
         self.assertEqual(bucket.metadata.bucket_id, "test-bucket-name")
         self.assertEqual(bucket.metadata.storage_class, "REGIONAL")
         self.assertLess(0, bucket.metadata.metageneration)
 
         rest = bucket.rest()
         self.assertNotEqual(int(rest.get("projectNumber")), 0)
+
+    def test_init_grpc_with_project(self):
+        request = storage_pb2.CreateBucketRequest(
+            parent="projects/_",
+            bucket_id="test-bucket-name",
+            bucket=storage_pb2.Bucket(
+                storage_class="REGIONAL",
+                project="projects/test-project",
+            ),
+        )
+        context = unittest.mock.Mock()
+        bucket, _ = gcs.bucket.Bucket.init_grpc(request, context)
+        self.assertEqual(bucket.metadata.name, "projects/_/buckets/test-bucket-name")
+        self.assertTrue(
+            bucket.metadata.project.startswith("projects/"), msg=bucket.metadata.project
+        )
+        self.assertEqual(bucket.metadata.bucket_id, "test-bucket-name")
+        self.assertEqual(bucket.metadata.storage_class, "REGIONAL")
+        self.assertLess(0, bucket.metadata.metageneration)
+
+        rest = bucket.rest()
+        self.assertNotEqual(int(rest.get("projectNumber")), 0)
+
+    def test_init_grpc_too_many_projects(self):
+        request = storage_pb2.CreateBucketRequest(
+            parent="projects/test-project",
+            bucket_id="test-bucket-name",
+            bucket=storage_pb2.Bucket(
+                storage_class="REGIONAL",
+                project="projects/different-project",
+            ),
+        )
+        context = unittest.mock.Mock()
+        context.abort.side_effect = TestBucketGrpc._raise_grpc_error
+        with self.assertRaises(Exception) as _:
+            _, _ = gcs.bucket.Bucket.init_grpc(request, context)
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.INVALID_ARGUMENT, unittest.mock.ANY
+        )
 
     def test_init_validates_names(self):
         request = storage_pb2.CreateBucketRequest(
@@ -80,7 +122,7 @@ class TestBucketGrpc(unittest.TestCase):
                 grpc.StatusCode.INVALID_ARGUMENT, unittest.mock.ANY
             )
 
-    def test_init_validates_project(self):
+    def test_init_validates_parent(self):
         invalid_projects = ["projects/", "pr/test-project", "projects/foo/bar/baz"]
         for project in invalid_projects:
             request = storage_pb2.CreateBucketRequest(
@@ -91,6 +133,22 @@ class TestBucketGrpc(unittest.TestCase):
             context = unittest.mock.Mock()
             context.abort.side_effect = TestBucketGrpc._raise_grpc_error
             with self.assertRaises(Exception, msg="project <%s>" % project) as _:
+                _, _ = gcs.bucket.Bucket.init_grpc(request, context)
+            context.abort.assert_called_once_with(
+                grpc.StatusCode.INVALID_ARGUMENT, unittest.mock.ANY
+            )
+
+    def test_init_validates_project(self):
+        invalid_projects = ["projects/", "pr/test-project", "projects/foo/bar/baz"]
+        for name in invalid_projects:
+            request = storage_pb2.CreateBucketRequest(
+                parent="projects/_",
+                bucket_id="test-bucket-name",
+                bucket=storage_pb2.Bucket(project=name),
+            )
+            context = unittest.mock.Mock()
+            context.abort.side_effect = TestBucketGrpc._raise_grpc_error
+            with self.assertRaises(Exception, msg="project <%s>" % name) as _:
                 _, _ = gcs.bucket.Bucket.init_grpc(request, context)
             context.abort.assert_called_once_with(
                 grpc.StatusCode.INVALID_ARGUMENT, unittest.mock.ANY


### PR DESCRIPTION
In gRPC we need to support project names in both the `parent` field and
the `bucket.project` fields.  Add some code to validate the field in
either case.