### PR TITLE
Fix: precondition creation in WriteObject

### DIFF
--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -154,7 +154,9 @@ class Upload(types.SimpleNamespace):
         fake_request = testbench.common.FakeRequest.init_protobuf(request, context)
         fake_request.update_protobuf(request.write_object_spec, context)
         upload = cls.init(fake_request, metadata, bucket, "", upload_id)
-        upload.preconditions = testbench.common.make_grpc_preconditions(request.write_object_spec)
+        upload.preconditions = testbench.common.make_grpc_preconditions(
+            request.write_object_spec
+        )
         return upload
 
     @classmethod

--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -154,7 +154,7 @@ class Upload(types.SimpleNamespace):
         fake_request = testbench.common.FakeRequest.init_protobuf(request, context)
         fake_request.update_protobuf(request.write_object_spec, context)
         upload = cls.init(fake_request, metadata, bucket, "", upload_id)
-        upload.preconditions = testbench.common.make_grpc_preconditions(request)
+        upload.preconditions = testbench.common.make_grpc_preconditions(request.write_object_spec)
         return upload
 
     @classmethod

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1305,8 +1305,11 @@ class TestGrpc(unittest.TestCase):
             ),
             finish_write=True,
         )
-        with self.assertRaises(grpc.RpcError):
-            _ = self.grpc.WriteObject([r1], context=self.mock_context())
+        context = unittest.mock.Mock()
+        context.abort = unittest.mock.MagicMock()
+        context.invocation_metadata = unittest.mock.MagicMock(return_value=dict())
+        self.grpc.WriteObject([r1], context=context)
+        context.abort.assert_called_once()
 
     def test_rewrite_object(self):
         # We need a large enough payload to make sure the first rewrite does

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1260,7 +1260,6 @@ class TestGrpc(unittest.TestCase):
 
     def test_object_write_conditional(self):
         media = TestGrpc._create_block(1024).encode("utf-8")
-
         r1 = storage_pb2.WriteObjectRequest(
             write_object_spec=storage_pb2.WriteObjectSpec(
                 resource={
@@ -1284,7 +1283,7 @@ class TestGrpc(unittest.TestCase):
         self.assertEqual(blob.bucket, "projects/_/buckets/bucket-name")
 
     def test_object_write_conditional_overwrite(self):
-        media = b"._-=-_." * 1024
+        media = TestGrpc._create_block(1024).encode("utf-8")
         request = testbench.common.FakeRequest(
             args={"name": "object-name"}, data=media, headers={}, environ={}
         )


### PR DESCRIPTION
For the gRPC WriteObject path, the preconditions are put in WriteObjecSpec rather
than directly in the request, like other objects.
