### PR TITLE
Fix: ReadObject with byte ranges sets ContentRange

### DIFF
--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -493,7 +493,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         content_range = None
         if request.read_offset > 0 or request.read_limit > 0:
             content_range = storage_pb2.ContentRange(
-                    start=start, end=read_end, complete_length=len(blob.media)
+                start=start, end=read_end, complete_length=len(blob.media)
             )
 
         while start <= read_end:

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1004,6 +1004,9 @@ class TestGrpc(unittest.TestCase):
             c.checksummed_data.crc32c, crc32c.crc32c(c.checksummed_data.content)
         )
         self.assertEqual(media[1:11], c.checksummed_data.content)
+        self.assertEqual(1, c.content_range.start)
+        self.assertEqual(11, c.content_range.end)
+        self.assertEqual(len(media), c.content_range.complete_length)
 
     def test_read_zero_size_object(self):
         request = testbench.common.FakeRequest(


### PR DESCRIPTION
When gRPC ReadObject has a byte range request, set the ContentRange field.