### PR TITLE
fix(gRPC): validate ReadObject.read_offset

### DIFF
--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -489,7 +489,9 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         start = request.read_offset
         read_end = len(blob.media)
         if start > read_end:
-            google3.third_party.storage_testbench.testbench.error.range_not_satisfiable(context=context)
+            google3.third_party.storage_testbench.testbench.error.range_not_satisfiable(
+                context=context
+            )
             return
         if request.read_limit > 0:
             read_end = min(read_end, start + request.read_limit)

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -488,6 +488,9 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         size = storage_pb2.ServiceConstants.Values.MAX_READ_CHUNK_BYTES
         start = request.read_offset
         read_end = len(blob.media)
+        if start > read_end:
+            google3.third_party.storage_testbench.testbench.error.range_not_satisfiable(context=context)
+            return
         if request.read_limit > 0:
             read_end = min(read_end, start + request.read_limit)
         content_range = None

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -489,7 +489,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         start = request.read_offset
         read_end = len(blob.media)
         if start > read_end:
-            testbench.error.range_not_satisfiable(context=context)
+            testbench.error.range_not_satisfiable(context)
             return
         if request.read_limit > 0:
             read_end = min(read_end, start + request.read_limit)

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -489,8 +489,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         start = request.read_offset
         read_end = len(blob.media)
         if start > read_end:
-            testbench.error.range_not_satisfiable(context)
-            return
+            return testbench.error.range_not_satisfiable(context)
         if request.read_limit > 0:
             read_end = min(read_end, start + request.read_limit)
         content_range = None

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -489,7 +489,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         start = request.read_offset
         read_end = len(blob.media)
         if start > read_end:
-            google3.third_party.storage_testbench.testbench.error.range_not_satisfiable(
+            testbench.error.range_not_satisfiable(
                 context=context
             )
             return

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -489,9 +489,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         start = request.read_offset
         read_end = len(blob.media)
         if start > read_end:
-            testbench.error.range_not_satisfiable(
-                context=context
-            )
+            testbench.error.range_not_satisfiable(context=context)
             return
         if request.read_limit > 0:
             read_end = min(read_end, start + request.read_limit)

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1036,7 +1036,7 @@ class TestGrpc(unittest.TestCase):
         context = unittest.mock.Mock()
         context.abort = unittest.mock.MagicMock()
         context.invocation_metadata = unittest.mock.MagicMock(return_value=dict())
-        self.grpc.ReadObject(
+        response = self.grpc.ReadObject(
             storage_pb2.ReadObjectRequest(
                 bucket="projects/_/buckets/bucket-name",
                 object="object-name",
@@ -1044,6 +1044,8 @@ class TestGrpc(unittest.TestCase):
             ),
             context,
         )
+        for r in response:
+            pass
         context.abort.assert_called_once()
 
     def test_update_object(self):

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1042,7 +1042,7 @@ class TestGrpc(unittest.TestCase):
                 object="object-name",
                 read_offset=10,
             ),
-            context=context,
+            context,
         )
         context.abort.assert_called_once()
 

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1044,8 +1044,8 @@ class TestGrpc(unittest.TestCase):
             ),
             context,
         )
-        for r in response:
-            pass
+        chunks = [r for r in response]
+        self.assertEqual(0, len(chunks))
         context.abort.assert_called_once()
 
     def test_update_object(self):


### PR DESCRIPTION
When a GCS request is made, read_offset is compared with the object size, and if it's too large, an error is returned.