### PR TITLE
feat: initial scaffolding to add Retry Test API in gRPC

### DIFF
--- a/testbench/common.py
+++ b/testbench/common.py
@@ -740,12 +740,16 @@ def __get_limit_response_fn(database, upload_id, test_id, method, limit):
 def grpc_handle_retry_test_instruction(database, request, context, method):
     test_id = None
     if context is not None:
-        if hasattr(context, "invocation_metadata"):
+        if hasattr(context, "invocation_metadata") and isinstance(
+            context.invocation_metadata(), tuple
+        ):
             for key, value in context.invocation_metadata():
                 if key == "x-retry-test-id":
                     test_id = value
     # Validate retry instructions, method and request transport.
-    if not test_id or not database.has_instructions_retry_test(test_id, method, transport="GRPC"):
+    if not test_id or not database.has_instructions_retry_test(
+        test_id, method, transport="GRPC"
+    ):
         return __get_default_response_fn
     next_instruction = database.peek_next_instruction(test_id, method)
     error_code_matches = testbench.common.retry_return_error_code.match(

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -24,7 +24,6 @@ import re
 import socket
 import struct
 import types
-from collections.abc import Iterable
 from functools import wraps
 
 import flask
@@ -742,12 +741,9 @@ def grpc_handle_retry_test_instruction(database, request, context, method):
     test_id = None
     if context is not None:
         if hasattr(context, "invocation_metadata") and isinstance(
-            context.invocation_metadata(), Iterable  # Handle mocks in tests
+            context.invocation_metadata(), tuple  # Handle mocks in tests
         ):
-            metadata = context.invocation_metadata()
-            if not isinstance(metadata, dict):
-                metadata = dict(metadata)
-            for key, value in metadata.items():
+            for key, value in context.invocation_metadata():
                 if key == "x-retry-test-id":
                     test_id = value
     # Validate retry instructions, method and request transport.

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -776,20 +776,6 @@ def grpc_handle_retry_test_instruction(database, request, context, method):
     return __get_default_response_fn
 
 
-def map_closest_http_to_grpc(http_code):
-    # Only map the status codes that are used in tests and listed in
-    # the README, to avoid error-prone code conversions.
-    status_map = {
-        "400": StatusCode.INVALID_ARGUMENT,
-        "401": StatusCode.UNAUTHENTICATED,
-        "408": StatusCode.DEADLINE_EXCEEDED,
-        "500": StatusCode.INTERNAL,
-        "503": StatusCode.UNAVAILABLE,
-        "504": StatusCode.DEADLINE_EXCEEDED,
-    }
-    return status_map[http_code]
-
-
 def handle_retry_test_instruction(database, request, socket_closer, method):
     upload_id = request.args.get("upload_id", None)
     test_id = request.headers.get("x-retry-test-id", None)
@@ -1117,3 +1103,17 @@ def bucket_name_from_proto(bucket_name):
 
 def bucket_name_to_proto(bucket_name):
     return "projects/_/buckets/" + bucket_name
+
+
+def map_closest_http_to_grpc(http_code):
+    # Only map the status codes that are used in tests and listed in
+    # the README, to avoid error-prone code conversions.
+    status_map = {
+        "400": StatusCode.INVALID_ARGUMENT,
+        "401": StatusCode.UNAUTHENTICATED,
+        "408": StatusCode.DEADLINE_EXCEEDED,
+        "500": StatusCode.INTERNAL,
+        "503": StatusCode.UNAVAILABLE,
+        "504": StatusCode.DEADLINE_EXCEEDED,
+    }
+    return status_map.get(http_code, None)

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -736,6 +736,28 @@ def __get_limit_response_fn(database, upload_id, test_id, method, limit):
 
     return limited_response_fn
 
+def grpc_handle_retry_test_instruction(database, request, context, method):
+    print("!!!!!!! entered new retry test decorator")
+    print("!!!!!!! entered new retry test decorator")
+    print("!!!!!!! entered new retry test decorator")
+    import pdb; pdb.set_trace()
+    test_id = request.headers.get("x-retry-test-id", None)
+    # if not test_id or not database.has_instructions_retry_test(test_id, method):
+    #     return __get_default_response_fn
+    next_instruction = database.peek_next_instruction(test_id, method)
+    error_code_matches = testbench.common.retry_return_error_code.match(
+        next_instruction
+    )
+    if error_code_matches:
+        database.dequeue_next_instruction(test_id, method)
+        items = list(error_code_matches.groups())
+        error_code = items[0]
+        error_message = {
+            "error": {"message": "Retry Test: Caused a {}".format(error_code)}
+        }
+        testbench.error.generic(
+            msg=error_message, rest_code=error_code, grpc_code=None, context=None
+        )
 
 def handle_retry_test_instruction(database, request, socket_closer, method):
     upload_id = request.args.get("upload_id", None)

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -28,6 +28,7 @@ from functools import wraps
 
 import flask
 import scalpl
+from collections.abc import Iterable
 from google.protobuf import timestamp_pb2
 from grpc import StatusCode
 from requests_toolbelt import MultipartDecoder
@@ -741,9 +742,12 @@ def grpc_handle_retry_test_instruction(database, request, context, method):
     test_id = None
     if context is not None:
         if hasattr(context, "invocation_metadata") and isinstance(
-            context.invocation_metadata(), tuple
+            context.invocation_metadata(), Iterable  # Handle mocks in tests
         ):
-            for key, value in context.invocation_metadata():
+            metadata = context.invocation_metadata()
+            if not isinstance(metadata, dict):
+                metadata = dict(metadata)
+            for key, value in metadata.items():
                 if key == "x-retry-test-id":
                     test_id = value
     # Validate retry instructions, method and request transport.

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -32,8 +32,7 @@ import scalpl
 from google.protobuf import timestamp_pb2
 from grpc import StatusCode
 from requests_toolbelt import MultipartDecoder
-from requests_toolbelt.multipart.decoder import \
-    ImproperBodyPartContentException
+from requests_toolbelt.multipart.decoder import ImproperBodyPartContentException
 
 import testbench
 from google.storage.v2 import storage_pb2

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -24,15 +24,16 @@ import re
 import socket
 import struct
 import types
+from collections.abc import Iterable
 from functools import wraps
 
 import flask
 import scalpl
-from collections.abc import Iterable
 from google.protobuf import timestamp_pb2
 from grpc import StatusCode
 from requests_toolbelt import MultipartDecoder
-from requests_toolbelt.multipart.decoder import ImproperBodyPartContentException
+from requests_toolbelt.multipart.decoder import \
+    ImproperBodyPartContentException
 
 import testbench
 from google.storage.v2 import storage_pb2

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -417,7 +417,7 @@ class Database:
     def __validate_grpc_method_implemented_retry(self, method):
         """Returns Unimplemented 501 for methods that are not yet supported.
         Temporary validation while adding Retry Test API support in gRPC."""
-        implemented_grpc_w_retry = ("storage.buckets.get")
+        implemented_grpc_w_retry = {"storage.buckets.get"}
         if method not in implemented_grpc_w_retry:
             testbench.error.unimplemented(
                 "Retry Test API support for the requested method <%s> in GRPC" % method,
@@ -444,7 +444,7 @@ class Database:
                 None,
             )
 
-    def insert_retry_test(self, instructions, transport):
+    def insert_retry_test(self, instructions, transport="JSON"):
         with self._retry_tests_lock:
             # Validate transport - Invalid request for any value other than "JSON" or "GRPC".
             self.__validate_transport(transport)

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -414,9 +414,10 @@ class Database:
                 return
         testbench.error.invalid("The fault injection request <%s>" % failure, None)
 
-    def __validate_grpc_method_implemented_retry(method):
-        """Temporary validation while adding Retry Test API support in gRPC."""
-        implemented_grpc_w_retry = "storage.objects.get"
+    def __validate_grpc_method_implemented_retry(self, method):
+        """Returns Unimplemented 501 for methods that are not yet supported.
+        Temporary validation while adding Retry Test API support in gRPC."""
+        implemented_grpc_w_retry = ("storage.buckets.get")
         if method not in implemented_grpc_w_retry:
             testbench.error.unimplemented(
                 "Retry Test API support for the requested method <%s> in GRPC" % method,
@@ -446,7 +447,6 @@ class Database:
     def insert_retry_test(self, instructions, transport):
         with self._retry_tests_lock:
             # Validate transport - Invalid request for any value other than "JSON" or "GRPC".
-            transport = transport.upper()
             self.__validate_transport(transport)
             self.__validate_instructions(instructions, transport)
             retry_test_id = uuid.uuid4().hex
@@ -456,7 +456,7 @@ class Database:
                     key: collections.deque(value) for key, value in instructions.items()
                 },
                 "completed": False,
-                "transport": transport,
+                "transport": transport.upper(),
             }
             return self.__to_serializeable_retry_test(self._retry_tests[retry_test_id])
 
@@ -466,7 +466,7 @@ class Database:
             # Add validation for request transport as well.
             if (len(retry_test["instructions"].get(method, [])) > 0) and retry_test[
                 "transport"
-            ] == transport.upper():
+            ].upper() == transport.upper():
                 return True
             return False
 

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -384,6 +384,7 @@ class Database:
                 key: list(value) for key, value in retry_test["instructions"].items()
             },
             "completed": retry_test["completed"],
+            "transport": retry_test["transport"].upper(),
         }
 
     def supported_methods(self):
@@ -413,18 +414,41 @@ class Database:
                 return
         testbench.error.invalid("The fault injection request <%s>" % failure, None)
 
-    def __validate_instructions(self, instructions):
+    def __validate_grpc_method_implemented_retry(method):
+        """Temporary validation while adding Retry Test API support in gRPC."""
+        implemented_grpc_w_retry = "storage.objects.get"
+        if method not in implemented_grpc_w_retry:
+            testbench.error.unimplemented(
+                "Retry Test API support for the requested method <%s> in GRPC" % method,
+                None,
+            )
+
+    def __validate_instructions(self, instructions, transport="JSON"):
         for method, failures in instructions.items():
             if method not in self._supported_methods:
                 testbench.error.invalid(
                     "The requested method <%s> for fault injection" % method, None
                 )
+            # TODO: Temporary validation will be removed once Retry Test API is fully supported in gRPC.
+            if transport.upper() == "GRPC":
+                self.__validate_grpc_method_implemented_retry(method)
             for failure in failures:
                 self.__validate_injected_failure_description(failure)
 
-    def insert_retry_test(self, instructions):
+    def __validate_transport(self, transport):
+        if transport.upper() not in ("JSON", "GRPC"):
+            testbench.error.invalid(
+                "The requested transport <%s> is not supported in the testbench"
+                % transport,
+                None,
+            )
+
+    def insert_retry_test(self, instructions, transport):
         with self._retry_tests_lock:
-            self.__validate_instructions(instructions)
+            # Validate transport - Invalid request for any value other than "JSON" or "GRPC".
+            transport = transport.upper()
+            self.__validate_transport(transport)
+            self.__validate_instructions(instructions, transport)
             retry_test_id = uuid.uuid4().hex
             self._retry_tests[retry_test_id] = {
                 "id": retry_test_id,
@@ -432,16 +456,17 @@ class Database:
                     key: collections.deque(value) for key, value in instructions.items()
                 },
                 "completed": False,
+                "transport": transport,
             }
             return self.__to_serializeable_retry_test(self._retry_tests[retry_test_id])
 
-    def has_instructions_retry_test(self, retry_test_id, method):
+    def has_instructions_retry_test(self, retry_test_id, method, transport="JSON"):
         with self._retry_tests_lock:
-            self.get_retry_test(retry_test_id)
-            if (
-                len(self._retry_tests[retry_test_id]["instructions"].get(method, []))
-                > 0
-            ):
+            retry_test = self.get_retry_test(retry_test_id)
+            # Add validation for request transport as well.
+            if (len(retry_test["instructions"].get(method, [])) > 0) and retry_test[
+                "transport"
+            ] == transport.upper():
                 return True
             return False
 

--- a/testbench/error.py
+++ b/testbench/error.py
@@ -153,9 +153,17 @@ def range_not_satisfiable(
     )
 
 
+def unimplemented(msg, context, rest_code=501, grpc_code=grpc.StatusCode.UNIMPLEMENTED):
+    """Error returned when an operation is not implemented/supported."""
+    generic(
+        _simple_json_error("%s is not implemented." % msg),
+        rest_code,
+        grpc_code,
+        context,
+    )
+
+
 def inject_error(context, rest_code, grpc_code, msg=""):
     """Inject error in grpc_server forced by the Retry Test API."""
     msg = "Retry Test: Caused a %s. %s" % (grpc_code, msg)
-    generic(
-        _simple_json_error(msg), rest_code, grpc_code, context
-    )
+    generic(_simple_json_error(msg), rest_code, grpc_code, context)

--- a/testbench/error.py
+++ b/testbench/error.py
@@ -151,3 +151,11 @@ def range_not_satisfiable(
         grpc_code,
         context,
     )
+
+
+def inject_error(context, rest_code, grpc_code, msg=""):
+    """Inject error in grpc_server forced by the Retry Test API."""
+    msg = "Retry Test: Caused a %s. %s" % (grpc_code, msg)
+    generic(
+        _simple_json_error(msg), rest_code, grpc_code, context
+    )

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -169,6 +169,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         )
         return empty_pb2.Empty()
 
+    @retry_test("storage.buckets.get")
     def GetBucket(self, request, context):
         bucket = self.db.get_bucket(
             request.name,
@@ -485,9 +486,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         self.db.delete_upload(request.upload_id, context)
         return storage_pb2.CancelResumableWriteResponse()
 
-    @retry_test("storage.objects.get")
     def GetObject(self, request, context):
-        print("### GRPC ### GetObject")
         blob = self.db.get_object(
             request.bucket,
             request.object,

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -117,10 +117,12 @@ def _metadata_echo_decorator(function):
 
     return decorated
 
+
 def _retry_test_decorator(function):
     """
-    Send back the invocation metadata as initial metadata, if metadata echo is
-    enabled.
+    Decorates a routing function to handle the Retry Test API,
+    with method names based on the JSON API.
+    TODO: add extra wrapper for method name
     """
     @functools.wraps(function)
     def decorated(self, request, context):
@@ -130,43 +132,6 @@ def _retry_test_decorator(function):
         return response_handler(function(self,request,context))
     return decorated
 
-# def _gen_retry_test_decorator(db):
-#     def retry_test(self, request, context, method):
-#         import flask
-#         self.db.insert_supported_methods([method])
-
-#         def decorator(function):
-#             @functools.wraps(function)
-#             def wrapper(*args, **kwargs):
-#                 response_handler = testbench.common.handle_retry_test_instruction(
-#                     self.db, flask.request, testbench.common._make_closer(flask.request), method
-#                 )
-#                 return response_handler(function(*args, **kwargs))
-
-#             return wrapper
-
-#         return decorator
-
-#     return retry_test
-
-
-# def gen_retry_test_decorator(db):
-#     def retry_test(method):
-#         db.insert_supported_methods([method])
-
-#         def decorator(func):
-#             @wraps(func)
-#             def wrapper(*args, **kwargs):
-#                 response_handler = handle_retry_test_instruction(
-#                     db, flask.request, _make_closer(flask.request), method
-#                 )
-#                 return response_handler(func(*args, **kwargs))
-
-#             return wrapper
-
-#         return decorator
-
-#     return retry_test
 
 def decorate_all_rpc_methods(klass):
     """Decorate all the RPC-looking methods."""
@@ -519,12 +484,6 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
 
     def GetObject(self, request, context):
         print("### GRPC ### GetObject")
-        # test_id = "sample727testid727"
-        # method = "storage.objects.get"
-        # if self.db.has_instructions_retry_test(test_id, method):
-        #     next_instruction = self.db.peek_next_instruction(test_id, method)
-        #     print(f"next instruction is {next_instruction}")
-        import pdb; pdb.set_trace()
         blob = self.db.get_object(
             request.bucket,
             request.object,

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -130,7 +130,7 @@ def retry_test(method):
             response_handler = testbench.common.grpc_handle_retry_test_instruction(
                 self.db, request, context, method=method
             )
-            return response_handler(function(self,request,context))
+            return response_handler(function(self, request, context))
 
         return wrapper
 

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -117,6 +117,56 @@ def _metadata_echo_decorator(function):
 
     return decorated
 
+def _retry_test_decorator(function):
+    """
+    Send back the invocation metadata as initial metadata, if metadata echo is
+    enabled.
+    """
+    @functools.wraps(function)
+    def decorated(self, request, context):
+        response_handler = testbench.common.grpc_handle_retry_test_instruction(
+            self.db, request, context, method="storage.objects.get"
+        )
+        return response_handler(function(self,request,context))
+    return decorated
+
+# def _gen_retry_test_decorator(db):
+#     def retry_test(self, request, context, method):
+#         import flask
+#         self.db.insert_supported_methods([method])
+
+#         def decorator(function):
+#             @functools.wraps(function)
+#             def wrapper(*args, **kwargs):
+#                 response_handler = testbench.common.handle_retry_test_instruction(
+#                     self.db, flask.request, testbench.common._make_closer(flask.request), method
+#                 )
+#                 return response_handler(function(*args, **kwargs))
+
+#             return wrapper
+
+#         return decorator
+
+#     return retry_test
+
+
+# def gen_retry_test_decorator(db):
+#     def retry_test(method):
+#         db.insert_supported_methods([method])
+
+#         def decorator(func):
+#             @wraps(func)
+#             def wrapper(*args, **kwargs):
+#                 response_handler = handle_retry_test_instruction(
+#                     db, flask.request, _make_closer(flask.request), method
+#                 )
+#                 return response_handler(func(*args, **kwargs))
+
+#             return wrapper
+
+#         return decorator
+
+#     return retry_test
 
 def decorate_all_rpc_methods(klass):
     """Decorate all the RPC-looking methods."""
@@ -125,7 +175,8 @@ def decorate_all_rpc_methods(klass):
             continue
         value = getattr(klass, key)
         if isinstance(value, types.FunctionType):
-            wrapped = _metadata_echo_decorator(value)
+            function = _metadata_echo_decorator(value)
+            wrapped = _retry_test_decorator(function)
             wrapped = _logging_method_decorator(wrapped)
             setattr(klass, key, wrapped)
     return klass
@@ -467,6 +518,13 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         return storage_pb2.CancelResumableWriteResponse()
 
     def GetObject(self, request, context):
+        print("### GRPC ### GetObject")
+        # test_id = "sample727testid727"
+        # method = "storage.objects.get"
+        # if self.db.has_instructions_retry_test(test_id, method):
+        #     next_instruction = self.db.peek_next_instruction(test_id, method)
+        #     print(f"next instruction is {next_instruction}")
+        import pdb; pdb.set_trace()
         blob = self.db.get_object(
             request.bucket,
             request.object,
@@ -829,6 +887,8 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
 
 def run(port, database, echo_metadata=False):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+    global retry_test
+    retry_test = testbench.common.gen_retry_test_decorator(database)
     storage_pb2_grpc.add_StorageServicer_to_server(
         StorageServicer(database, echo_metadata), server
     )

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -850,8 +850,6 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
 
 def run(port, database, echo_metadata=False):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
-    global retry_test
-    retry_test = testbench.common.gen_retry_test_decorator(database)
     storage_pb2_grpc.add_StorageServicer_to_server(
         StorageServicer(database, echo_metadata), server
     )

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -137,7 +137,9 @@ def create_retry_test():
         return flask.Response(
             "instructions is not defined", status=400, content_type="text/plain"
         )
-    retry_test = db.insert_retry_test(test_instruction_set)
+    # Backfill a newly added field "transport" in the retry test resource.
+    transport = payload.get("transport", "JSON")
+    retry_test = db.insert_retry_test(test_instruction_set, transport)
     retry_test_response = json.dumps(retry_test)
     return flask.Response(
         retry_test_response, status=200, content_type="application/json"

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -220,6 +220,7 @@ def bucket_insert():
 @gcs.route("/b/<bucket_name>")
 @retry_test(method="storage.buckets.get")
 def bucket_get(bucket_name):
+    print("### REST SERVER ### bucket_get")
     db.insert_test_bucket()
     db.insert_test_bucket()
     bucket = db.get_bucket(
@@ -556,6 +557,7 @@ def object_delete(bucket_name, object_name):
 @gcs.route("/b/<bucket_name>/o/<path:object_name>")
 @retry_test(method="storage.objects.get")
 def object_get(bucket_name, object_name):
+    print("### REST SERVER ### object_get")
     blob = db.get_object(
         bucket_name,
         object_name,

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -222,7 +222,6 @@ def bucket_insert():
 @gcs.route("/b/<bucket_name>")
 @retry_test(method="storage.buckets.get")
 def bucket_get(bucket_name):
-    print("### REST SERVER ### bucket_get")
     db.insert_test_bucket()
     db.insert_test_bucket()
     bucket = db.get_bucket(
@@ -559,7 +558,6 @@ def object_delete(bucket_name, object_name):
 @gcs.route("/b/<bucket_name>/o/<path:object_name>")
 @retry_test(method="storage.objects.get")
 def object_get(bucket_name, object_name):
-    print("### REST SERVER ### object_get")
     blob = db.get_object(
         bucket_name,
         object_name,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1206,6 +1206,13 @@ class TestCommonUtils(unittest.TestCase):
             ),
         )
 
+    def test_map_closest_http_to_grpc(self):
+        self.assertEqual(
+            grpc.StatusCode.UNAVAILABLE,
+            testbench.common.map_closest_http_to_grpc("503"),
+        )
+        self.assertIsNone(testbench.common.map_closest_http_to_grpc("302"))
+
     def test_handle_gzip_request(self):
         # Test gzip decompresses request payload when Content-Encoding: gzip is present.
         payload = b'{"name": "bucket-name"}'

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -453,6 +453,26 @@ class TestDatabaseRetryTest(unittest.TestCase):
             _ = database.insert_retry_test({"storage.buckets.get": ["return-429"]})
         self.assertEqual(rest.exception.code, 400)
 
+    def test_insert_retry_test_invalid_transport(self):
+        database = testbench.database.Database.init()
+        database.insert_supported_methods(["storage.buckets.get"])
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            _ = database.insert_retry_test(
+                {"storage.buckets.get": ["return-429"]}, transport="THRIFT"
+            )
+        self.assertEqual(rest.exception.code, 400)
+
+    def test_insert_retry_test_unimplemented_grpc_method(self):
+        database = testbench.database.Database.init()
+        database.insert_supported_methods(["storage.resumable.upload"])
+
+        with self.assertRaises(testbench.error.RestException) as rest:
+            _ = database.insert_retry_test(
+                {"storage.resumable.upload": ["return-429"]}, transport="GRPC"
+            )
+        self.assertEqual(rest.exception.code, 501)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -84,6 +84,28 @@ class TestError(unittest.TestCase):
             error.notallowed(None)
         self.assertEqual(rest.exception.code, 405)
 
+    def test_unimplemented(self):
+        with self.assertRaises(error.RestException) as rest:
+            error.unimplemented("requested method", None)
+        self.assertEqual(rest.exception.code, 501)
+
+        context = Mock()
+        error.unimplemented("requested method", context)
+        context.abort.assert_called_once_with(grpc.StatusCode.UNIMPLEMENTED, ANY)
+
+    def test_inject_error(self):
+        with self.assertRaises(error.RestException) as rest:
+            error.inject_error(
+                None, rest_code=503, grpc_code=grpc.StatusCode.UNAVAILABLE
+            )
+        self.assertEqual(rest.exception.code, 503)
+
+        context = Mock()
+        error.inject_error(
+            context, rest_code=503, grpc_code=grpc.StatusCode.UNAVAILABLE
+        )
+        context.abort.assert_called_once_with(grpc.StatusCode.UNAVAILABLE, ANY)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_testbench_retry.py
+++ b/tests/test_testbench_retry.py
@@ -594,7 +594,7 @@ class TestTestbenchRetryGrpc(unittest.TestCase):
 
         context = unittest.mock.Mock()
         context.invocation_metadata = unittest.mock.Mock(
-            return_value={"x-retry-test-id": create_rest.get("id")}
+            return_value=(("x-retry-test-id", create_rest.get("id")),)
         )
         response = self.grpc.GetBucket(
             storage_pb2.GetBucketRequest(name="projects/_/buckets/bucket-name"), context
@@ -620,7 +620,7 @@ class TestTestbenchRetryGrpc(unittest.TestCase):
 
         context = unittest.mock.Mock()
         context.invocation_metadata = unittest.mock.Mock(
-            return_value={"x-retry-test-id": create_rest.get("id")}
+            return_value=(("x-retry-test-id", create_rest.get("id")),)
         )
         response = self.grpc.GetBucket(
             storage_pb2.GetBucketRequest(name="projects/_/buckets/bucket-name"), context

--- a/tests/test_testbench_retry.py
+++ b/tests/test_testbench_retry.py
@@ -22,11 +22,12 @@ import re
 import unittest
 import unittest.mock
 
+from grpc import StatusCode
+
 import gcs
 import testbench
-from testbench import rest_server
 from google.storage.v2 import storage_pb2
-from grpc import StatusCode
+from testbench import rest_server
 
 UPLOAD_QUANTUM = 256 * 1024
 


### PR DESCRIPTION
-  Initial scaffolding for new retry test handler in the gRPC server 
    - enable method `GetBucket`
    - error-codes-matches (e.g. return-503) 
    - retry_connection_matches (e.g. return-reset-connection)

- Add new field `"transport": "JSON"` to the Retry Test Resource
    - trigger retry test cases for specified transport(s), returns 501 Unimplemented for operations not yet supported 
    - validate and distinguish retry test instructions for specified transport

- Add error code mapping between HTTP and gRPC


- [x] Tests pass
- Appropriate changes to README will be added when the support is completed