### PR TITLE
feat: support retry test return-X-after-YK for uploads in grpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ curl -H "x-retry-test-id: 1d05c20627844214a9ff7cbcf696317d" "http://localhost:91
 | Failure Id              | Description
 | ----------------------- | ---
 | return-X                                  | [HTTP] Testbench will fail with HTTP code provided for X, e.g. return-503 returns a 503  <br> [GRPC] Testbench will fail with the equivalent gRPC error to the HTTP code provided for X (X currently supported in the gRPC context include `400`, `401`, `429`, `500`, `501`, `503`)
-| return-X-after-YK                         | [HTTP] Testbench will return X after YKiB of uploaded data
+| return-X-after-YK                         | [HTTP] Testbench will return X after YKiB of uploaded data <br> [GRPC] Testbench will return the equivalent gRPC error to the HTTP code provided for X after YKiB of uploaded data (X currently supported in the gRPC context include `400`, `401`, `429`, `500`, `501`, `503`)
 | return-broken-stream-final-chunk-after-YB | [HTTP] Testbench will break connection on final chunk of a resumable upload after Y bytes
 | return-broken-stream                      | [HTTP] Testbench will fail after a few downloaded bytes <br> [GRPC] Testbench will fail with `UNAVAILABLE` after a few downloaded bytes
 | return-broken-stream-after-YK             | [HTTP] Testbench will fail after YKiB of downloaded data <br> [GRPC] Testbench will fail with `UNAVAILABLE` after YKiB of downloaded data

--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -218,7 +218,40 @@ class Upload(types.SimpleNamespace):
                         context,
                     )
                     return None, False
-            upload.media += checksummed_data.content
+
+            # Handle retry test return-X-after-YK failures if applicable.
+            (
+                rest_code,
+                after_bytes,
+                test_id,
+            ) = testbench.common.get_retry_uploads_error_after_bytes(
+                db, request, context=context, transport="GRPC"
+            )
+            expected_persisted_size = request.write_offset + len(content)
+            if rest_code:
+                testbench.common.handle_grpc_retry_uploads_error_after_bytes(
+                    context,
+                    upload,
+                    content,
+                    db,
+                    rest_code,
+                    after_bytes,
+                    write_offset=request.write_offset,
+                    persisted_size=len(upload.media),
+                    expected_persisted_size=expected_persisted_size,
+                    test_id=test_id,
+                )
+
+            # The testbench should ignore any request bytes that have already been persisted,
+            # thus we validate write_offset against persisted_size.
+            # https://github.com/googleapis/googleapis/blob/15b48f9ed0ae8b034e753c6895eb045f436e257c/google/storage/v2/storage.proto#L320-L329
+            if request.write_offset < len(upload.media):
+                range_start = len(upload.media) - request.write_offset
+                content = testbench.common.partial_media(
+                    content, range_end=len(content), range_start=range_start
+                )
+
+            upload.media += content
             if request.finish_write:
                 upload.complete = True
 

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -869,7 +869,7 @@ def get_retry_uploads_error_after_bytes(
     if not test_id:
         return 0, 0, ""
     next_instruction = None
-    if database.has_instructions_retry_test(test_id, method, transport):
+    if database.has_instructions_retry_test(test_id, method, transport=transport):
         next_instruction = database.peek_next_instruction(test_id, method)
     if not next_instruction:
         return 0, 0, ""

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -425,6 +425,7 @@ class Database:
             "storage.hmacKey.list",
             "storage.notifications.get",
             "storage.notifications.list",
+            "storage.objects.insert",
             "storage.objects.list",
             "storage.objects.get",
             "storage.serviceaccount.get",

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -465,10 +465,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         bucket = self.db.get_bucket(request.destination.bucket, context).metadata
         metadata = storage_pb2.Object()
         metadata.MergeFrom(request.destination)
-        (
-            blob,
-            _,
-        ) = gcs.object.Object.init(
+        (blob, _,) = gcs.object.Object.init(
             request, metadata, composed_media, bucket, True, context
         )
         self.db.insert_object(

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -465,7 +465,10 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         bucket = self.db.get_bucket(request.destination.bucket, context).metadata
         metadata = storage_pb2.Object()
         metadata.MergeFrom(request.destination)
-        (blob, _,) = gcs.object.Object.init(
+        (
+            blob,
+            _,
+        ) = gcs.object.Object.init(
             request, metadata, composed_media, bucket, True, context
         )
         self.db.insert_object(
@@ -663,6 +666,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
     def __get_bucket(self, bucket_name, context) -> storage_pb2.Bucket:
         return self.db.get_bucket(bucket_name, context).metadata
 
+    @retry_test(method="storage.objects.insert")
     def WriteObject(self, request_iterator, context):
         upload, is_resumable = gcs.upload.Upload.init_write_object_grpc(
             self.db, request_iterator, context

--- a/tests/test_testbench_retry.py
+++ b/tests/test_testbench_retry.py
@@ -22,6 +22,8 @@ import re
 import unittest
 import unittest.mock
 
+import crc32c
+
 from grpc import StatusCode
 
 import gcs
@@ -706,6 +708,84 @@ class TestTestbenchRetryGrpc(unittest.TestCase):
             StatusCode.UNAVAILABLE,
             "Injected 'broken stream' fault",
         )
+
+    def test_grpc_return_error_after_bytes(self):
+        # Setup two after-bytes errors to test injecting failures in
+        # resumable uploads, both multiple chunks and a single chunk.
+        response = self.rest_client.post(
+            "/retry_test",
+            data=json.dumps(
+                {
+                    "instructions": {
+                        "storage.objects.insert": [
+                            "return-503-after-256K",
+                            "return-503-after-300K",
+                        ]
+                    },
+                    "transport": "GRPC",
+                }
+            ),
+        )
+        self.assertEqual(response.status_code, 200)
+        create_rest = json.loads(response.data)
+        self.assertIn("id", create_rest)
+        id = create_rest.get("id")
+
+        context = unittest.mock.Mock()
+        context.invocation_metadata = unittest.mock.Mock(
+            return_value=(("x-retry-test-id", id),)
+        )
+        start = self.grpc.StartResumableWrite(
+            storage_pb2.StartResumableWriteRequest(
+                write_object_spec=storage_pb2.WriteObjectSpec(
+                    resource=storage_pb2.Object(
+                        name="object-name", bucket="projects/_/buckets/bucket-name"
+                    )
+                )
+            ),
+            context=context,
+        )
+        self.assertIsNotNone(start.upload_id)
+
+        # Upload the first 256KiB chunk of data and trigger error.
+        content = self._create_block(UPLOAD_QUANTUM).encode("utf-8")
+        r1 = storage_pb2.WriteObjectRequest(
+            upload_id=start.upload_id,
+            write_offset=0,
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=content, crc32c=crc32c.crc32c(content)
+            ),
+            finish_write=False,
+        )
+        write = self.grpc.WriteObject([r1], context)
+        context.abort.assert_called_with(StatusCode.UNAVAILABLE, unittest.mock.ANY)
+
+        status = self.grpc.QueryWriteStatus(
+            storage_pb2.QueryWriteStatusRequest(upload_id=start.upload_id),
+            context,
+        )
+        self.assertEqual(status.persisted_size, UPLOAD_QUANTUM)
+
+        # Send a full object upload here to verify testbench can
+        # (1) trigger error_after_bytes instructions,
+        # (2) ignore duplicate request bytes and
+        # (3) return a forced failure with partial data.
+        media = self._create_block(2 * UPLOAD_QUANTUM).encode("utf-8")
+        r2 = storage_pb2.WriteObjectRequest(
+            upload_id=start.upload_id,
+            write_offset=0,
+            checksummed_data=storage_pb2.ChecksummedData(
+                content=media, crc32c=crc32c.crc32c(media)
+            ),
+            finish_write=True,
+        )
+        write = self.grpc.WriteObject([r2], context)
+        context.abort.assert_called_with(StatusCode.UNAVAILABLE, unittest.mock.ANY)
+        self.assertIsNotNone(write)
+        blob = write.resource
+        self.assertEqual(blob.name, "object-name")
+        self.assertEqual(blob.bucket, "projects/_/buckets/bucket-name")
+        self.assertEqual(blob.size, 2 * UPLOAD_QUANTUM)
 
 
 if __name__ == "__main__":

--- a/tests/test_testbench_retry.py
+++ b/tests/test_testbench_retry.py
@@ -23,7 +23,6 @@ import unittest
 import unittest.mock
 
 import crc32c
-
 from grpc import StatusCode
 
 import gcs


### PR DESCRIPTION
Add Retry Test API support for return-X-after-YK in gRPC WriteObject

- [x] Tests pass
- [x] Appropriate changes to README are included in PR