### PR TITLE
fix: pin `Werkzeug` version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov
           pip install -e .
+          pip list
       - name: Run Unit Tests with Coverage
         env:
           PYTHONPATH: "."

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
         "testbench/servers",
         "gcs",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     install_requires=[
         "grpcio==1.59.0",
         "googleapis-common-protos==1.60.0",
@@ -52,5 +52,6 @@ setuptools.setup(
         "crc32c==2.3",
         "gunicorn==21.2.0",
         "waitress==2.1.2",
+        "Werkzeug==3.0.0",
     ],
 )


### PR DESCRIPTION
`Werkzeug` is a direct dependency, we should pin it too. I also noticed the Python version needed fixing. And it would be nice to see what is installed for troubleshooting purposes.

Motivated by #547 
