### PR TITLE
ci: deflake code coverage uploads

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,7 @@ jobs:
           pytest --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        if: ${{ matrix.python-version }} == "3.11"
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true
@@ -60,12 +61,3 @@ jobs:
           PYTHONPATH: "."
         run: |
           pytest --cov=./ --cov-report=xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          env_vars: OS,PYTHON
-          fail_ci_if_error: true
-          files: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-          verbose: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
           pytest --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
-        if: ${{ matrix.python-version }} == "3.11"
+        if: ${{ matrix.python-version == '3.11' }}
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true


### PR DESCRIPTION
Only upload code coverage results for Python 3.11 on Linux. Uploading all the results seems to flake (maybe too may parallel uploads?).
