### PR TITLE
fix: races in Object metadata updates

### DIFF
--- a/testbench/database.py
+++ b/testbench/database.py
@@ -13,17 +13,16 @@
 # limitations under the License.
 
 import collections
+import copy
 import json
 import os
 import pathlib
 import threading
 import uuid
-import copy
-from typing import TypeVar, Any, Callable
+from typing import Any, Callable, TypeVar
 
 import gcs
 import testbench
-
 
 T = TypeVar('T')
 
@@ -291,7 +290,7 @@ class Database:
             )
             # return a snapshot copy of the blob/blob.metadata
             if blob is None:
-                return blob
+                return None
             b = copy.copy(blob)
             b.metadata = copy.copy(blob.metadata)
             return b
@@ -354,7 +353,7 @@ class Database:
                 bucket_name, object_name, context, generation, preconditions
             )
             return update_fn(blob, live_generation)
-        
+
     # === UPLOAD === #
 
     def get_upload(self, upload_id, context):

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -24,7 +24,7 @@ from typing import Any, Callable, TypeVar
 import gcs
 import testbench
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 class Database:

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -338,7 +338,7 @@ class Database:
             bucket = self.__get_bucket_for_object(bucket_name, context)
             bucket.pop("%s#%d" % (blob.metadata.name, blob.metadata.generation), None)
 
-    def do_update(
+    def do_update_object(
         self,
         bucket_name: str,
         object_name: str,

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -290,6 +290,8 @@ class Database:
                 bucket_name, object_name, context, generation, preconditions
             )
             # return a snapshot copy of the blob/blob.metadata
+            if blob is None:
+                return blob
             b = copy.copy(blob)
             b.metadata = copy.copy(blob.metadata)
             return b

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -667,7 +667,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
 
         self.db.insert_test_bucket()
 
-        return self.db.get_object(
+        return self.db.do_update(
             request.object.bucket,
             request.object.name,
             context=context,

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -667,7 +667,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
 
         self.db.insert_test_bucket()
 
-        return self.db.do_update(
+        return self.db.do_update_object(
             request.object.bucket,
             request.object.name,
             context=context,

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -626,7 +626,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
 
         acls = None
         if request.predefined_acl:
-           acls = testbench.acl.compute_predefined_object_acl(
+            acls = testbench.acl.compute_predefined_object_acl(
                 request.object.bucket,
                 request.object.name,
                 request.object.generation,

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -518,7 +518,7 @@ def object_update(bucket_name, object_name):
             blob.rest_metadata(), projection, fields
         )
 
-    return db.do_update(
+    return db.do_update_object(
         bucket_name,
         object_name,
         generation=flask.request.args.get("generation", None),
@@ -542,7 +542,7 @@ def object_patch(bucket_name, object_name):
             blob.rest_metadata(), projection, fields
         )
 
-    return db.do_update(
+    return db.do_update_object(
         bucket_name,
         object_name,
         generation=flask.request.args.get("generation", None),
@@ -812,7 +812,7 @@ def object_acl_insert(bucket_name, object_name):
         )
         return testbench.common.filter_response_rest(response, None, fields)
 
-    return db.do_update(
+    return db.do_update_object(
         bucket_name,
         object_name,
         generation=flask.request.args.get("generation", None),
@@ -853,7 +853,7 @@ def object_acl_update(bucket_name, object_name, entity):
         )
         return testbench.common.filter_response_rest(response, None, fields)
 
-    return db.do_update(
+    return db.do_update_object(
         bucket_name,
         object_name,
         generation=flask.request.args.get("generation", None),
@@ -879,7 +879,7 @@ def object_acl_patch(bucket_name, object_name, entity):
         )
         return testbench.common.filter_response_rest(response, None, fields)
 
-    return db.do_update(
+    return db.do_update_object(
         bucket_name,
         object_name,
         generation=flask.request.args.get("generation", None),
@@ -895,7 +895,7 @@ def object_acl_delete(bucket_name, object_name, entity):
     def update_impl(blob, live_generation):
         blob.delete_acl(entity, None)
 
-    db.do_update(
+    db.do_update_object(
         bucket_name,
         object_name,
         generation=flask.request.args.get("generation", None),

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -801,6 +801,7 @@ def object_acl_list(bucket_name, object_name):
 @retry_test(method="storage.object_acl.insert")
 def object_acl_insert(bucket_name, object_name):
     fields = flask.request.args.get("fields", None)
+
     def update_impl(blob, live_generation):
         del live_generation
         acl = blob.insert_acl(flask.request, None)
@@ -841,6 +842,7 @@ def object_acl_get(bucket_name, object_name, entity):
 @retry_test(method="storage.object_acl.update")
 def object_acl_update(bucket_name, object_name, entity):
     fields = flask.request.args.get("fields", None)
+
     def update_impl(blob, live_generation):
         del live_generation
         acl = blob.update_acl(flask.request, entity, None)
@@ -885,12 +887,13 @@ def object_acl_patch(bucket_name, object_name, entity):
     )
 
 
-
 @gcs.route("/b/<bucket_name>/o/<path:object_name>/acl/<entity>", methods=["DELETE"])
 @retry_test(method="storage.object_acl.delete")
 def object_acl_delete(bucket_name, object_name, entity):
+
     def update_impl(blob, live_generation):
         blob.delete_acl(entity, None)
+
     db.do_update(
         bucket_name,
         object_name,

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -510,6 +510,7 @@ def object_list(bucket_name):
 def object_update(bucket_name, object_name):
     projection = testbench.common.extract_projection(flask.request, "full", None)
     fields = flask.request.args.get("fields", None)
+
     def update_impl(blob, live_generation):
         del live_generation
         blob.update(flask.request, None)
@@ -533,6 +534,7 @@ def object_patch(bucket_name, object_name):
     testbench.common.enforce_patch_override(flask.request)
     projection = testbench.common.extract_projection(flask.request, "full", None)
     fields = flask.request.args.get("fields", None)
+
     def patch_impl(blob, live_generation):
         del live_generation
         blob.patch(flask.request, None)

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -517,7 +517,7 @@ def object_update(bucket_name, object_name):
             blob.rest_metadata(), projection, fields
         )
 
-    return db.get_object(
+    return db.do_update(
         bucket_name,
         object_name,
         generation=flask.request.args.get("generation", None),
@@ -540,7 +540,7 @@ def object_patch(bucket_name, object_name):
             blob.rest_metadata(), projection, fields
         )
 
-    return db.get_object(
+    return db.do_update(
         bucket_name,
         object_name,
         generation=flask.request.args.get("generation", None),

--- a/testbench/rest_server.py
+++ b/testbench/rest_server.py
@@ -892,7 +892,6 @@ def object_acl_patch(bucket_name, object_name, entity):
 @gcs.route("/b/<bucket_name>/o/<path:object_name>/acl/<entity>", methods=["DELETE"])
 @retry_test(method="storage.object_acl.delete")
 def object_acl_delete(bucket_name, object_name, entity):
-
     def update_impl(blob, live_generation):
         blob.delete_acl(entity, None)
 


### PR DESCRIPTION
Tensorstore has a test which does concurrent reads/writes to storage testbench.

(https://github.com/google/tensorstore/blob/41812f367837989d91c7e1ae8548ecfa166e70be/tensorstore/kvstore/gcs_grpc/gcs_grpc_testbench_test.cc#L169)

The test spawns N threads. Each thread uses conditional operations to atomically update a region of the object.

This test currently is flaky due to missing object locking in storage-testbench.

Before this change, the database returned an object which was modified outside of the lock.
After this change, the modifications to the database object happen while a lock is held.

