### PR TITLE
fix: handle WriteObject final message with empty data

### DIFF
--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -201,6 +201,10 @@ class Upload(types.SimpleNamespace):
             data = request.WhichOneof("data")
             if data == "checksummed_data":
                 checksummed_data = request.checksummed_data
+            elif data is None and request.finish_write:
+                # Handles final message with no data to insert.
+                upload.complete = True
+                continue
             else:
                 print("WARNING unexpected data field %s\n" % data)
                 continue

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -776,6 +776,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
 
         return response
 
+    @retry_test(method="storage.objects.insert")
     def StartResumableWrite(self, request, context):
         bucket = self.__get_bucket(request.write_object_spec.resource.bucket, context)
         upload = gcs.upload.Upload.init_resumable_grpc(request, bucket, context)


### PR DESCRIPTION
- Return object resource and finalize a resumable session for a `WriteObjectRequest` w/ `finish_write: true` w/o checksummed_data
- Apply grpc retry wrapper to `StartResumableWrite`
- Updated tests

Fixes #574

