### PR TITLE
test: add mutation test case

### DIFF
--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -208,8 +208,8 @@ class Upload(types.SimpleNamespace):
                 upload.complete = True
                 continue
             else:
-                print("WARNING unexpected data field %s\n" % data)
-                continue
+                testbench.error.invalid("Invalid data field in upload", context)
+                return None, False
 
             content = checksummed_data.content
             crc32c_hash = (
@@ -332,8 +332,7 @@ class Upload(types.SimpleNamespace):
                 upload.complete = True
                 continue
             else:
-                print("WARNING unexpected data field %s\n" % data)
-                continue
+                return testbench.error.invalid("Invalid data field in upload", context)
 
             content = checksummed_data.content
             crc32c_hash = (

--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -210,6 +210,7 @@ class Upload(types.SimpleNamespace):
             else:
                 print("WARNING unexpected data field %s\n" % data)
                 continue
+
             content = checksummed_data.content
             crc32c_hash = (
                 checksummed_data.crc32c if checksummed_data.HasField("crc32c") else None
@@ -329,6 +330,9 @@ class Upload(types.SimpleNamespace):
             elif data is None and request.finish_write:
                 # Handles final message with no data to insert.
                 upload.complete = True
+                continue
+            else:
+                print("WARNING unexpected data field %s\n" % data)
                 continue
 
             content = checksummed_data.content


### PR DESCRIPTION
Context: mutation test caught missing test case in internal cl/609739391


Not sure why productive coverage check is angry as there is test coverage through
https://github.com/googleapis/storage-testbench/blob/a60a7145a67098e7c6cd4142391e240b3d462ecc/tests/test_grpc_server.py#L2113-L2151
