### PR TITLE
chore: drop cloud-cxx-team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/cloud-storage-dpe @googleapis/cloud-cxx-owners @coryan
+*     @googleapis/cloud-storage-dpe @coryan


### PR DESCRIPTION
Drop @googleapis/cloud-cxx-owners (who no longer have Write privileges) as CODEOWNERS.