### PR TITLE
feat: enable more methods for retry test support in gRPC

### DIFF
--- a/testbench/database.py
+++ b/testbench/database.py
@@ -446,22 +446,29 @@ class Database:
     def __validate_grpc_method_implemented_retry(self, method):
         """Returns Unimplemented 501 for methods that are not yet supported.
         Temporary validation while adding Retry Test API support in gRPC."""
-        implemented_grpc_w_retry = {
-            "storage.buckets.get",
-            "storage.buckets.getIamPolicy",
-            "storage.buckets.list",
-            "storage.hmacKey.get",
-            "storage.hmacKey.list",
-            "storage.notifications.get",
-            "storage.notifications.list",
-            "storage.objects.insert",
-            "storage.objects.list",
-            "storage.objects.get",
-            "storage.serviceaccount.get",
+        not_supported_grpc_w_retry = {
+            "storage.bucket_acl.get",
+            "storage.bucket_acl.list",
+            "storage.bucket_acl.delete",
+            "storage.bucket_acl.insert",
+            "storage.bucket_acl.patch",
+            "storage.bucket_acl.update",
+            "storage.default_object_acl.get",
+            "storage.default_object_acl.list",
+            "storage.default_object_acl.delete",
+            "storage.default_object_acl.insert",
+            "storage.default_object_acl.patch",
+            "storage.default_object_acl.update",
+            "storage.object_acl.get",
+            "storage.object_acl.list",
+            "storage.object_acl.delete",
+            "storage.object_acl.insert",
+            "storage.object_acl.patch",
+            "storage.object_acl.update",
         }
-        if method not in implemented_grpc_w_retry:
+        if method in not_supported_grpc_w_retry:
             testbench.error.unimplemented(
-                "Retry Test API support for the requested method <%s> in GRPC" % method,
+                "Retry Test API not supported for the requested method <%s> in GRPC" % method,
                 None,
             )
 

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -465,6 +465,10 @@ class Database:
             "storage.object_acl.insert",
             "storage.object_acl.patch",
             "storage.object_acl.update",
+            "storage.notifications.delete",
+            "storage.notifications.get",
+            "storage.notifications.insert",
+            "storage.notifications.list",
         }
         if method in not_supported_grpc_w_retry:
             testbench.error.unimplemented(

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -468,7 +468,8 @@ class Database:
         }
         if method in not_supported_grpc_w_retry:
             testbench.error.unimplemented(
-                "Retry Test API not supported for the requested method <%s> in GRPC" % method,
+                "Retry Test API not supported for the requested method <%s> in GRPC"
+                % method,
                 None,
             )
 

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -373,7 +373,6 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         notification_id = notification_name[loc + len("/notificationConfigs/") :]
         return (bucket_name, notification_id)
 
-    @retry_test(method="storage.notifications.delete")
     def DeleteNotificationConfig(self, request, context):
         bucket_name, notification_id = self._decompose_notification_name(
             request.name, context
@@ -384,7 +383,6 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         bucket.delete_notification(notification_id, context)
         return empty_pb2.Empty()
 
-    @retry_test(method="storage.notifications.get")
     def GetNotificationConfig(self, request, context):
         bucket_name, notification_id = self._decompose_notification_name(
             request.name, context
@@ -395,7 +393,6 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         rest = bucket.get_notification(notification_id, context)
         return self._notification_from_rest(rest, bucket_name)
 
-    @retry_test(method="storage.notifications.insert")
     def CreateNotificationConfig(self, request, context):
         pattern = "^//pubsub.googleapis.com/projects/[^/]+/topics/[^/]+$"
         if re.match(pattern, request.notification_config.topic) is None:
@@ -412,7 +409,6 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         rest = bucket.insert_notification(json.dumps(notification), context)
         return self._notification_from_rest(rest, request.parent)
 
-    @retry_test("storage.notifications.list")
     def ListNotificationConfigs(self, request, context):
         bucket = self.db.get_bucket(request.parent, context)
         items = bucket.list_notifications(context).get("items", [])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -465,11 +465,11 @@ class TestDatabaseRetryTest(unittest.TestCase):
 
     def test_insert_retry_test_unimplemented_grpc_method(self):
         database = testbench.database.Database.init()
-        database.insert_supported_methods(["storage.resumable.upload"])
+        database.insert_supported_methods(["storage.bucket_acl.get"])
 
         with self.assertRaises(testbench.error.RestException) as rest:
             _ = database.insert_retry_test(
-                {"storage.resumable.upload": ["return-429"]}, transport="GRPC"
+                {"storage.bucket_acl.get": ["return-429"]}, transport="GRPC"
             )
         self.assertEqual(rest.exception.code, 501)
 


### PR DESCRIPTION
Allow more methods for Retry Test support in gRPC

- equip gRPC endpoints with @retry_test decorator
- update `__validate_grpc_method_implemented_retry` guard
- 501 Unimplemented exceptions are only raised for ACL and notifications test cases that are not applicable in gRPC