### PR TITLE
ci: provide codecov with its token

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,8 +47,9 @@ jobs:
         if: ${{ matrix.python-version == '3.12' }}
         uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
         with:
-          action: codecov/codecov-action@v3
+          action: codecov/codecov-action@v4
           with: |
+            token: ${{ secrets.CODECOV_TOKEN }}
             env_vars: OS,PYTHON
             fail_ci_if_error: true
             files: ./coverage.xml


### PR DESCRIPTION
It seems that codecov.io now requires tokens for all uploads:

https://github.com/codecov/codecov-action?tab=readme-ov-file#v4-release

> **Breaking Changes** Tokenless uploading is unsupported
