### PR TITLE
fix: map 504 errors to DEADLINE_EXCEEDED

### DIFF
--- a/testbench/common.py
+++ b/testbench/common.py
@@ -1182,6 +1182,6 @@ def _grpc_forced_failure_from_http_instruction(http_code):
         "429": StatusCode.RESOURCE_EXHAUSTED,
         "500": StatusCode.INTERNAL,
         "503": StatusCode.UNAVAILABLE,
-        "504": StatusCode.UNAVAILABLE,  # TODO: Unresolved discussion on whether DEADLINE_EXCEEDED is retryable client-side based on AIP#194
+        "504": StatusCode.DEADLINE_EXCEEDED,
     }
     return status_map.get(http_code, None)


### PR DESCRIPTION
This is needed to test behavior with DEADLINE_EXCEEDED errors for gRPC. GCS is still returning these errors in some cases for internal timeouts so we need to be able to test this.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR