### PR TITLE
fix: Update cloudbuild.yaml to use $SHORT_SHA to infra tag images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,4 +36,4 @@ steps:
 images:
   - gcr.io/cloud-devrel-public-resources/storage-testbench:$TAG_NAME
   - gcr.io/cloud-devrel-public-resources/storage-testbench:latest
-  - gcr.io/cloud-devrel-public-resources/storage-testbench:infrastructure-public-image-tb-latest
+  - gcr.io/cloud-devrel-public-resources/storage-testbench:infrastructure-public-image-$SHORT_SHA


### PR DESCRIPTION
Fixes #671
