### PR TITLE
feat(read): add redirect semantics for BidiReadObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ Testbench will fail redirectable RPCs with `routing_token` set to the value `T`
 
 In gRPC, set initial metadata with `x-goog-emulator-instructions: redirect-send-handle-and-token-tokenval`.
 Testbench will fail redirectable RPCs with `routing_token` set to the value `T`
-(`tokenval` in the example) and a `write_handle` (`read_handle` is not currently
-supported).
+(`tokenval` in the example) and a `write_handle` or `read_handle` depending on the method called( `storage.objects.insert` or `storage.objects.get` ).
 
 ### redirect-expect-token-T
 

--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -392,7 +392,7 @@ class Upload(types.SimpleNamespace):
         if first_msg.HasField("object_checksums"):
             object_checksums = first_msg.object_checksums
 
-        return_redirect_token = testbench.common.get_return_handle_and_redirect_token(
+        return_redirect_token = testbench.common.get_return_write_handle_and_redirect_token(
             db, context
         )
         if return_redirect_token:

--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -393,8 +393,7 @@ class Upload(types.SimpleNamespace):
             object_checksums = first_msg.object_checksums
 
         return_redirect_token = (
-            testbench.common.get_return_write_handle_and_redirect_token(
-            db, context)
+            testbench.common.get_return_write_handle_and_redirect_token(db, context)
         )
         if return_redirect_token:
             err = storage_pb2.BidiWriteObjectRedirectedError()

--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -392,8 +392,9 @@ class Upload(types.SimpleNamespace):
         if first_msg.HasField("object_checksums"):
             object_checksums = first_msg.object_checksums
 
-        return_redirect_token = testbench.common.get_return_write_handle_and_redirect_token(
-            db, context
+        return_redirect_token = (
+            testbench.common.get_return_write_handle_and_redirect_token(
+            db, context)
         )
         if return_redirect_token:
             err = storage_pb2.BidiWriteObjectRedirectedError()

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -1110,10 +1110,12 @@ def get_return_write_handle_and_redirect_token(db, context):
         db, context, "storage.objects.insert", retry_return_handle_and_redirection_token
     )
 
+
 def get_return_read_handle_and_redirect_token(db, context):
     return _get_grpc_instruction_match(
         db, context, "storage.objects.get", retry_return_handle_and_redirection_token
     )
+
 
 def get_expect_redirect_token(db, context):
     return _get_grpc_instruction_match(

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -1105,11 +1105,15 @@ def get_return_redirect_token(db, context):
     )
 
 
-def get_return_handle_and_redirect_token(db, context):
+def get_return_write_handle_and_redirect_token(db, context):
     return _get_grpc_instruction_match(
         db, context, "storage.objects.insert", retry_return_handle_and_redirection_token
     )
 
+def get_return_read_handle_and_redirect_token(db, context):
+    return _get_grpc_instruction_match(
+        db, context, "storage.objects.get", retry_return_handle_and_redirection_token
+    )
 
 def get_expect_redirect_token(db, context):
     return _get_grpc_instruction_match(

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -548,11 +548,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
             broken_stream_after_bytes = testbench.common.get_broken_stream_after_bytes(
                 next_instruction
             )
-        return_redirect_token = (
-                testbench.common.get_return_read_handle_and_redirect_token(
-                    self.db,context
-                )
-            )
+        return_redirect_token = testbench.common.get_return_read_handle_and_redirect_token(self.db,context)
 
         # first_response is protected by GIL
         first_response = True

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -548,7 +548,9 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
             broken_stream_after_bytes = testbench.common.get_broken_stream_after_bytes(
                 next_instruction
             )
-        return_redirect_token = testbench.common.get_return_read_handle_and_redirect_token(self.db,context)
+        return_redirect_token = (
+            testbench.common.get_return_read_handle_and_redirect_token(self.db,context)
+        )
 
         # first_response is protected by GIL
         first_response = True

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -549,7 +549,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
                 next_instruction
             )
         return_redirect_token = (
-            testbench.common.get_return_read_handle_and_redirect_token(self.db,context)
+            testbench.common.get_return_read_handle_and_redirect_token(self.db, context)
         )
 
         # first_response is protected by GIL

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -562,7 +562,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
             # We ignore the read_mask for this test server
             return resp
         
-        if len(return_redirect_token):
+        if return_redirect_token and len(return_redirect_token):
             detail = any_pb2.Any()
             detail.Pack(
                 storage_pb2.BidiReadObjectRedirectedError(

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -525,7 +525,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
             first_message = next(request_iterator)
         except StopIteration:
             # ok if no messages arrive from the client.
-            return   
+            return
 
         obj_spec = first_message.read_object_spec
         blob = self.db.get_object(
@@ -548,9 +548,9 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
             broken_stream_after_bytes = testbench.common.get_broken_stream_after_bytes(
                 next_instruction
             )
-            return_redirect_token = (
-            testbench.common.get_return_read_handle_and_redirect_token(
-                self.db,context
+        return_redirect_token = (
+                testbench.common.get_return_read_handle_and_redirect_token(
+                    self.db,context
                 )
             )
 

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -525,8 +525,8 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
             first_message = next(request_iterator)
         except StopIteration:
             # ok if no messages arrive from the client.
-            return
-        
+            return   
+
         obj_spec = first_message.read_object_spec
         blob = self.db.get_object(
             obj_spec.bucket,
@@ -548,7 +548,11 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
             broken_stream_after_bytes = testbench.common.get_broken_stream_after_bytes(
                 next_instruction
             )
-            return_redirect_token = testbench.common.get_return_read_handle_and_redirect_token(self.db,context)
+            return_redirect_token = (
+            testbench.common.get_return_read_handle_and_redirect_token(
+                self.db,context
+                )
+            )
 
         # first_response is protected by GIL
         first_response = True
@@ -561,7 +565,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
                 resp.read_handle.handle = b"an-opaque-handle"
             # We ignore the read_mask for this test server
             return resp
-        
+
         if return_redirect_token and len(return_redirect_token):
             detail = any_pb2.Any()
             detail.Pack(


### PR DESCRIPTION
Fixes Redirection in case of BidiReadObject. 

This adds instructions for returning a redirect error which includes the read_handle in details.

Other redirections( without read_handle ) are not possible in case of BidiRead.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR