### PR TITLE
feat: update appendable blob metadata crc32c field

### DIFF
--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -330,6 +330,7 @@ class Upload(types.SimpleNamespace):
             require_live_current_generation=False,
         )
 
+
     @classmethod
     def process_bidi_write_object_grpc(cls, db, request_iterator, context):
         """Process a BidiWriteObject streaming RPC, and yield a stream of responses."""
@@ -433,6 +434,27 @@ class Upload(types.SimpleNamespace):
                     msg.resource.size = obj_len
             return msg
 
+        def update_upload_checksums(upload_metadata, object_checksums):
+            if object_checksums is None:
+                upload_metadata.metadata["x_emulator_no_crc32c"] = "true"
+                upload_metadata.metadata["x_emulator_no_md5"] = "true"
+            else:
+                if object_checksums.HasField("crc32c"):
+                    upload_metadata.metadata[
+                        "x_emulator_crc32c"
+                    ] = testbench.common.rest_crc32c_from_proto(object_checksums.crc32c)
+                else:
+                    upload_metadata.metadata["x_emulator_no_crc32c"] = "true"
+                if (
+                    object_checksums.md5_hash is not None
+                    and object_checksums.md5_hash != b""
+                ):
+                    upload_metadata.metadata[
+                        "x_emulator_md5"
+                    ] = testbench.common.rest_md5_from_proto(object_checksums.md5_hash)
+                else:
+                    upload_metadata.metadata["x_emulator_no_md5"] = "true"
+
         for request in request_iterator:
             if request.HasField("first_message"):
                 testbench.error.invalid("Multiple first_message", context)
@@ -511,9 +533,12 @@ class Upload(types.SimpleNamespace):
                 # TODO(#720): (b) Decide if the testbench checks for flush or/and performs a background force-close.
                 if is_appendable:
 
+                    update_upload_checksums(upload.metadata, object_checksums)
+
                     def update_appendable_blob(blob, unused_generation):
                         blob.media = upload.media
                         blob.metadata.size = len(upload.media)
+                        blob.metadata.checksums.crc32c = crc32c.crc32c(upload.media)
                         return blob
 
                     blob = db.do_update_object(
@@ -540,25 +565,8 @@ class Upload(types.SimpleNamespace):
                     )
                 )
 
-        if object_checksums is None:
-            upload.metadata.metadata["x_emulator_no_crc32c"] = "true"
-            upload.metadata.metadata["x_emulator_no_md5"] = "true"
-        else:
-            if object_checksums.HasField("crc32c"):
-                upload.metadata.metadata[
-                    "x_emulator_crc32c"
-                ] = testbench.common.rest_crc32c_from_proto(object_checksums.crc32c)
-            else:
-                upload.metadata.metadata["x_emulator_no_crc32c"] = "true"
-            if (
-                object_checksums.md5_hash is not None
-                and object_checksums.md5_hash != b""
-            ):
-                upload.metadata.metadata[
-                    "x_emulator_md5"
-                ] = testbench.common.rest_md5_from_proto(object_checksums.md5_hash)
-            else:
-                upload.metadata.metadata["x_emulator_no_md5"] = "true"
+        # Update metadata checksums fields on the upload instance.
+        update_upload_checksums(upload.metadata, object_checksums)
 
         # Create a new object when the write is completed.
         if upload.complete:
@@ -609,3 +617,4 @@ class Upload(types.SimpleNamespace):
             response.headers["X-Http-Status-Code-Override"] = "308"
             response.status_code = 200
         return response
+

--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -616,4 +616,3 @@ class Upload(types.SimpleNamespace):
             response.headers["X-Http-Status-Code-Override"] = "308"
             response.status_code = 200
         return response
-

--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -330,7 +330,6 @@ class Upload(types.SimpleNamespace):
             require_live_current_generation=False,
         )
 
-
     @classmethod
     def process_bidi_write_object_grpc(cls, db, request_iterator, context):
         """Process a BidiWriteObject streaming RPC, and yield a stream of responses."""

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -2149,6 +2149,9 @@ class TestGrpc(unittest.TestCase):
             crc32c.crc32c(media),
             crc32c.crc32c(b"".join([c.checksummed_data.content for c in chunks])),
         )
+        self.assertEqual(
+            [crc32c.crc32c(media)], [c.metadata.checksums.crc32c for c in chunks]
+        )
 
     def test_bidi_write_object_no_requests(self):
         # The code depends on `context.abort()` raising an exception.


### PR DESCRIPTION
Updates `blob.metadata.checksums.crc32c` for an appendable blob



Towards #720 and related to #721

