### PR TITLE
fix: Handle partial writes better.

### DIFF
--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -231,6 +231,23 @@ class Upload(types.SimpleNamespace):
                     )
                     return None, False
 
+            # The testbench should ignore any request bytes that have already been persisted,
+            # thus we validate write_offset against persisted_size.
+            # https://github.com/googleapis/googleapis/blob/15b48f9ed0ae8b034e753c6895eb045f436e257c/google/storage/v2/storage.proto#L320-L329
+            if request.write_offset < len(upload.media):
+                range_start = len(upload.media) - request.write_offset
+                content = testbench.common.partial_media(
+                    content, range_end=len(content), range_start=range_start
+                )
+            if request.write_offset > len(upload.media):
+                context.abort(
+                        grpc.StatusCode.OUT_OF_RANGE,
+                        "Write offset %d does not match expected %d" % (
+                                request.write_offset,
+                                len(upload.media),
+                        ),
+                )
+
             # Handle retry test return-X-after-YK failures if applicable.
             (
                 rest_code,
@@ -239,7 +256,7 @@ class Upload(types.SimpleNamespace):
             ) = testbench.common.get_retry_uploads_error_after_bytes(
                 db, request, context=context, transport="GRPC"
             )
-            expected_persisted_size = request.write_offset + len(content)
+            expected_persisted_size = len(upload.media) + len(content)
             if rest_code:
                 testbench.common.handle_grpc_retry_uploads_error_after_bytes(
                     context,
@@ -248,19 +265,7 @@ class Upload(types.SimpleNamespace):
                     db,
                     rest_code,
                     after_bytes,
-                    write_offset=request.write_offset,
-                    persisted_size=len(upload.media),
-                    expected_persisted_size=expected_persisted_size,
                     test_id=test_id,
-                )
-
-            # The testbench should ignore any request bytes that have already been persisted,
-            # thus we validate write_offset against persisted_size.
-            # https://github.com/googleapis/googleapis/blob/15b48f9ed0ae8b034e753c6895eb045f436e257c/google/storage/v2/storage.proto#L320-L329
-            if request.write_offset < len(upload.media):
-                range_start = len(upload.media) - request.write_offset
-                content = testbench.common.partial_media(
-                    content, range_end=len(content), range_start=range_start
                 )
 
             upload.media += content
@@ -491,29 +496,6 @@ class Upload(types.SimpleNamespace):
                             context,
                         )
 
-                # Handle retry test return-X-after-YK failures if applicable.
-                (
-                    rest_code,
-                    after_bytes,
-                    test_id,
-                ) = testbench.common.get_retry_uploads_error_after_bytes(
-                    db, request, context=context, transport="GRPC"
-                )
-                expected_persisted_size = request.write_offset + len(content)
-                if rest_code:
-                    testbench.common.handle_grpc_retry_uploads_error_after_bytes(
-                        context,
-                        upload,
-                        content,
-                        db,
-                        rest_code,
-                        after_bytes,
-                        write_offset=request.write_offset,
-                        persisted_size=len(upload.media),
-                        expected_persisted_size=expected_persisted_size,
-                        test_id=test_id,
-                    )
-
                 # The testbench should ignore any request bytes that have already been persisted,
                 # thus we validate write_offset against persisted_size.
                 # https://github.com/googleapis/googleapis/blob/15b48f9ed0ae8b034e753c6895eb045f436e257c/google/storage/v2/storage.proto#L320-L329
@@ -522,6 +504,35 @@ class Upload(types.SimpleNamespace):
                     content = testbench.common.partial_media(
                         content, range_end=len(content), range_start=range_start
                     )
+                if request.write_offset > len(upload.media):
+                    context.abort(
+                            grpc.StatusCode.OUT_OF_RANGE,
+                            "Write offset %d does not match expected %d" % (
+                                    request.write_offset,
+                                    len(upload.media),
+                            ),
+                    )
+
+                # Handle retry test return-X-after-YK failures if applicable.
+                (
+                    rest_code,
+                    after_bytes,
+                    test_id,
+                ) = testbench.common.get_retry_uploads_error_after_bytes(
+                    db, request, context=context, transport="GRPC"
+                )
+                expected_persisted_size = len(upload.media) + len(content)
+                if rest_code:
+                    testbench.common.handle_grpc_retry_uploads_error_after_bytes(
+                        context,
+                        upload,
+                        content,
+                        db,
+                        rest_code,
+                        after_bytes,
+                        test_id=test_id,
+                    )
+
                 # Currently, the testbench will always checkpoint and flush data for testing purposes,
                 # instead of the 15 seconds interval used in the GCS server.
                 # TODO(#592): Refactor testbench checkpointing to more closely follow GCS server behavior.

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -1018,24 +1018,17 @@ def handle_grpc_retry_uploads_error_after_bytes(
     database,
     rest_code,
     after_bytes,
-    write_offset,
-    persisted_size,
-    expected_persisted_size,
     test_id,
 ):
     """
     Handle error-after-bytes instructions for resumable uploads in the grpc server and commit only partial data before forcing a testbench error.
     This helper method also ignores request bytes that have already been persisted, which aligns with GCS behavior.
     """
-    if after_bytes > len(upload.media) and after_bytes <= expected_persisted_size:
-        # Ignore request bytes that have already been persisted.
-        range_start = 0
-        if len(upload.media) != 0 and write_offset < persisted_size:
-            range_start = persisted_size - write_offset
+    if after_bytes > len(upload.media) and after_bytes <= len(upload.media) + len(data):
         # Only partial data will be commited due to the instructed interruption.
-        range_end = range_start + (after_bytes - len(upload.media))
+        range_end = after_bytes - len(upload.media)
         content = testbench.common.partial_media(
-            data, range_end=range_end, range_start=range_start
+            data, range_end=range_end, range_start=0
         )
         upload.media += content
         database.dequeue_next_instruction(test_id, "storage.objects.insert")


### PR DESCRIPTION
Writes with offsets larger than the media were not handled quite correctly. Address partial writes by first trimming the input content to the correct offset (or returning an error if the write_offset is too long), then handling any persist-then-break retry instructions.