### PR TITLE
feat(storage): Simulate object custom contexts

### DIFF
--- a/testbench/common.py
+++ b/testbench/common.py
@@ -1250,26 +1250,12 @@ def preprocess_object_metadata(metadata):
             checksums["md5Hash"] = md5Hash
     if len(checksums) > 0:
         md["checksums"] = checksums
-    # For the ACLs, if present, have fewer fields in gRPC, remove
+    # Finally the ACLs, if present, have fewer fields in gRPC, remove
     # them if present, ignore then otherwise
     if "acl" in md:
         for a in md["acl"]:
             for field in ["kind", "bucket", "object", "generation", "etag"]:
                 a.pop(field, None)
-    # For the contexts, if present, need to sanize the JSON null values to
-    # empty objects because Python's parseDict cannot iterate over a null map,
-    # or parse a null value into a message.
-    if "contexts" in md:
-        contexts = md["contexts"]
-        if "custom" in contexts:
-            custom_map = contexts["custom"]
-            if custom_map is None:
-                contexts["custom"] = {}
-            elif isinstance(custom_map, dict):
-                for key, val in custom_map.items():
-                    if val is None:
-                        custom_map[key] = {}
-
     return md
 
 

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -1250,12 +1250,26 @@ def preprocess_object_metadata(metadata):
             checksums["md5Hash"] = md5Hash
     if len(checksums) > 0:
         md["checksums"] = checksums
-    # Finally the ACLs, if present, have fewer fields in gRPC, remove
+    # For the ACLs, if present, have fewer fields in gRPC, remove
     # them if present, ignore then otherwise
     if "acl" in md:
         for a in md["acl"]:
             for field in ["kind", "bucket", "object", "generation", "etag"]:
                 a.pop(field, None)
+    # For the contexts, if present, need to sanize the JSON null values to
+    # empty objects because Python's parseDict cannot iterate over a null map,
+    # or parse a null value into a message.
+    if "contexts" in md:
+        contexts = md["contexts"]
+        if "custom" in contexts:
+            custom_map = contexts["custom"]
+            if custom_map is None:
+                contexts["custom"] = {}
+            elif isinstance(custom_map, dict):
+                for key, val in custom_map.items():
+                    if val is None:
+                        custom_map[key] = {}
+
     return md
 
 

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -488,10 +488,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         bucket = self.db.get_bucket(request.destination.bucket, context).metadata
         metadata = storage_pb2.Object()
         metadata.MergeFrom(request.destination)
-        (
-            blob,
-            _,
-        ) = gcs.object.Object.init(
+        (blob, _,) = gcs.object.Object.init(
             request, metadata, composed_media, bucket, True, context
         )
         self.db.insert_object(

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -157,6 +157,56 @@ def _metadata_echo_decorator(function):
     return decorated
 
 
+def _validate_object_contexts(contexts, grpc_context):
+    """
+    Validates a storage_pb2.Object.contexts message against API layer rules.
+    If validation fails, it aborts the gRPC request using testbench.error.invalid.
+    """
+    if not contexts or not contexts.custom:
+        return
+
+    custom_contexts = contexts.custom
+    if len(custom_contexts) > 50:
+        return testbench.error.invalid(
+            "The count of object context entries cannot exceed 50.", grpc_context
+        )
+
+    invalid_chars = {"'", '"', "\\", "/"}
+    total_size_bytes = 0
+
+    for key, payload in custom_contexts.items():
+        val = payload.value
+        if key.startswith("goog"):
+            return testbench.error.invalid(
+                f"Key '{key}' is invalid. Keys cannot begin with 'goog'.", grpc_context
+            )
+        for item, item_type in ((key, "Key"), (val, "Value")):
+            if not item or not item[0].isalnum():
+                return testbench.error.invalid(
+                    f"{item_type} '{item}' must begin with an alphanumeric character.",
+                    grpc_context,
+                )
+            if any(char in invalid_chars for char in item):
+                return testbench.error.invalid(
+                    f"{item_type} '{item}' contains restricted characters (', \", \\, /).",
+                    grpc_context,
+                )
+            encoded_item = item.encode("utf-8")
+            item_length = len(encoded_item)
+            if not (1 <= item_length <= 256):
+                return testbench.error.invalid(
+                    f"{item_type} '{item}' must be between 1 and 256 UTF-8 code units.",
+                    grpc_context,
+                )
+            total_size_bytes += item_length
+    max_size_bytes = 25 * 1024
+    if total_size_bytes > max_size_bytes:
+        return testbench.error.invalid(
+            f"Aggregate size of keys and values ({total_size_bytes} bytes) exceeds the 25 KiB limit.",
+            grpc_context,
+        )
+
+
 def retry_test(method):
     """
     Decorate a routing function to handle the Retry Test API instructions,
@@ -915,6 +965,10 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
                     object.contexts.custom[k].CopyFrom(v)
                 for k in removed_contexts_keys:
                     object.contexts.custom.pop(k, None)
+            
+            if object.HasField("contexts"):
+                _validate_object_contexts(object.contexts, context)
+
             object.metageneration += 1
             object.update_time.FromDatetime(curr_time)
             return object

--- a/testbench/grpc_server.py
+++ b/testbench/grpc_server.py
@@ -965,7 +965,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
                     object.contexts.custom[k].CopyFrom(v)
                 for k in removed_contexts_keys:
                     object.contexts.custom.pop(k, None)
-            
+
             if object.HasField("contexts"):
                 _validate_object_contexts(object.contexts, context)
 

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1174,9 +1174,7 @@ class TestGrpc(unittest.TestCase):
                         "location": storage_pb2.ObjectCustomContextPayload(
                             value="Canada"
                         ),
-                        "year": storage_pb2.ObjectCustomContextPayload(
-                            value="2026"
-                        ),
+                        "year": storage_pb2.ObjectCustomContextPayload(value="2026"),
                     }
                 ),
             ),

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1174,20 +1174,20 @@ class TestGrpc(unittest.TestCase):
                         "location": storage_pb2.ObjectCustomContextPayload(
                             value="Canada"
                         ),
-                        "googyear": storage_pb2.ObjectCustomContextPayload(
+                        "year": storage_pb2.ObjectCustomContextPayload(
                             value="2026"
                         ),
                     }
                 ),
             ),
             update_mask=field_mask_pb2.FieldMask(
-                paths=["contexts.custom.location", "contexts.custom.googyear"]
+                paths=["contexts.custom.location", "contexts.custom.year"]
             ),
         )
         context = unittest.mock.Mock()
         response = self.grpc.UpdateObject(request, context)
         assert_context_valid(response.contexts, "location", "Canada")
-        assert_context_valid(response.contexts, "googyear", "2026")
+        assert_context_valid(response.contexts, "year", "2026")
 
         # Finally verify the changes are persisted
         context = unittest.mock.Mock()
@@ -1198,7 +1198,7 @@ class TestGrpc(unittest.TestCase):
             context,
         )
         assert_context_valid(response.contexts, "location", "Canada")
-        assert_context_valid(response.contexts, "googyear", "2026")
+        assert_context_valid(response.contexts, "year", "2026")
 
     def test_update_object_contexts_invalid(self):
         media = b"How vexingly quick daft zebras jump!"

--- a/tests/test_grpc_server.py
+++ b/tests/test_grpc_server.py
@@ -1142,6 +1142,62 @@ class TestGrpc(unittest.TestCase):
         )
         self.assertEqual(response.metadata, {**response.metadata, **expected})
 
+    def test_update_object_contexts(self):
+        media = b"How vexingly quick daft zebras jump!"
+        request = testbench.common.FakeRequest(
+            args={"name": "object-name"},
+            data=media,
+            headers={},
+            environ={},
+        )
+        blob, _ = gcs.object.Object.init_media(request, self.bucket.metadata)
+        self.db.insert_object("bucket-name", blob, None)
+
+        def assert_context_valid(contexts, key, expected_value):
+            payload = contexts.custom.get(key)
+            self.assertIsNotNone(payload, f"Key '{key}' missing from custom contexts")
+            self.assertEqual(payload.value, expected_value)
+            # Verify timestamps are set (non-default)
+            self.assertGreater(
+                payload.create_time.seconds, 0, f"create_time not set for {key}"
+            )
+            self.assertGreater(
+                payload.update_time.seconds, 0, f"update_time not set for {key}"
+            )
+
+        request = storage_pb2.UpdateObjectRequest(
+            object=storage_pb2.Object(
+                bucket="projects/_/buckets/bucket-name",
+                name="object-name",
+                contexts=storage_pb2.ObjectContexts(
+                    custom={
+                        "location": storage_pb2.ObjectCustomContextPayload(
+                            value="Canada"
+                        ),
+                        "year": storage_pb2.ObjectCustomContextPayload(value="2026"),
+                    }
+                ),
+            ),
+            update_mask=field_mask_pb2.FieldMask(
+                paths=["contexts.custom.location", "contexts.custom.year"]
+            ),
+        )
+        context = unittest.mock.Mock()
+        response = self.grpc.UpdateObject(request, context)
+        assert_context_valid(response.contexts, "location", "Canada")
+        assert_context_valid(response.contexts, "year", "2026")
+
+        # Finally verify the changes are persisted
+        context = unittest.mock.Mock()
+        response = self.grpc.GetObject(
+            storage_pb2.GetObjectRequest(
+                bucket="projects/_/buckets/bucket-name", object="object-name"
+            ),
+            context,
+        )
+        assert_context_valid(response.contexts, "location", "Canada")
+        assert_context_valid(response.contexts, "year", "2026")
+
     def test_update_object_acl(self):
         media = b"How vexingly quick daft zebras jump!"
         request = testbench.common.FakeRequest(
@@ -2435,7 +2491,8 @@ class TestGrpc(unittest.TestCase):
 
     def test_bidi_read_no_messages_sent(self):
         streamer = self.grpc.BidiReadObject([], context=self.mock_context())
-        self.assertEqual(len(list(streamer)), 0)  # No responses, does not raise
+        # No responses, does not raise
+        self.assertEqual(len(list(streamer)), 0)
 
     def test_bidi_read_out_of_range_error(self):
         # Create object in database to read.

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -219,7 +219,9 @@ class TestObject(unittest.TestCase):
         )
         with self.assertRaises(ValueError) as context:
             blob.patch(patch_req, None)
-        self.assertIn("must begin with an alphanumeric character", str(context.exception))
+        self.assertIn(
+            "must begin with an alphanumeric character", str(context.exception)
+        )
 
         # --- Must be 1 - 256 UTF-8 code units (Testing 257 characters) ---
         long_string = "a" * 257
@@ -228,13 +230,13 @@ class TestObject(unittest.TestCase):
         )
         with self.assertRaises(ValueError) as context:
             blob.patch(patch_req, None)
-        self.assertIn("must be between 1 and 256 UTF-8 code units", str(context.exception))
+        self.assertIn(
+            "must be between 1 and 256 UTF-8 code units", str(context.exception)
+        )
 
         # --- Limit to 50 entries per object (Testing 51 entries) ---
         too_many_contexts = {f"key{i}": {"value": "val"} for i in range(51)}
-        patch_req = self._create_request(
-            {"contexts": {"custom": too_many_contexts}}
-        )
+        patch_req = self._create_request({"contexts": {"custom": too_many_contexts}})
         with self.assertRaises(ValueError) as context:
             blob.patch(patch_req, None)
         self.assertIn("cannot exceed 50", str(context.exception))


### PR DESCRIPTION
b/457332685

This simulates the Json and gRPC responses for object contexts, which
will be helpful in gcp c++ integration tests in gcp c++ feature implementation:

Based on responses observed from real backend and API definition,

**Insert or Complete Update**
Input: {contexts: {custom: {key: value}}}
Update_mask: contexts
Simulation: Add new entries to the object.contexts and furnish with create_time and update_time

**Patch (Update an existing key)**
Input: {contexts: {custom: {key: new-value}}}
Update_mask: contexts.custom.key
Simulation: Update the value of the key to "new-value" and furnish with update_time

**Patch (Delete an existing key)**
Input: {contexts: {custom: {key: null}}}
Update_mask: contexts.custom.key
Simulation: Delete that entry with that key from object.contexts

**Patch (Delete all the contexts)**
Input: {contexts: {custom: null}}
Update_mask: contexts:custom
Simulation: Delete the contexts field from object, making that object looks like its default
