### PR TITLE
chore: upgrade to latest grpcio

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     name: Unit Tests with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setuptools.setup(
         "testbench/servers",
         "gcs",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         "grpcio==1.80.0",
         "grpcio-status==1.66.1",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "grpcio==1.70.0",
+        "grpcio==1.80.0",
         "grpcio-status==1.66.1",
         "grpcio-tools==1.70.0",
         "googleapis-common-protos==1.69.0",


### PR DESCRIPTION
grpcio 1.70.0 does not have binaries for Python 3.14+ and does not compile cleanly on macOS

Also removes support for Python 3.8.0, which reached end-of-life on 2024-10-07 (and is not supported by grpcio 1.80.0)