### PR TITLE
feat: Add fault injection for finalize and close (half-close)

### DIFF
--- a/gcs/upload.py
+++ b/gcs/upload.py
@@ -525,6 +525,29 @@ class Upload(types.SimpleNamespace):
                     )
                 object_checksums = request.object_checksums
 
+            if request.finish_write:
+                return_redirect_token_finish = testbench.common.get_return_write_handle_and_redirect_token_on_finish_write(
+                    db, context
+                )
+                if return_redirect_token_finish:
+                    if handle is None:
+                        handle = str(blob.upload_gen).encode("utf-8")
+                    abort_with_redirect_error(
+                        return_redirect_token_finish,
+                        handle=handle,
+                        generation=upload.metadata.generation,
+                    )
+
+                error_code = testbench.common.get_return_error_code_on_finish_write(
+                    db, context
+                )
+                if error_code:
+                    grpc_status = testbench.common.http_to_grpc_status(error_code)
+                    context.abort(
+                        grpc_status,
+                        "Retry Test: Caused a %s" % str(grpc_status),
+                    )
+
             data = request.WhichOneof("data")
             if data == "checksummed_data":
                 checksummed_data = request.checksummed_data
@@ -628,6 +651,17 @@ class Upload(types.SimpleNamespace):
                             crc32c=persisted_crc32c
                         ),
                     )
+                )
+
+        if not upload.complete:
+            error_code = testbench.common.get_return_error_code_on_half_close(
+                db, context
+            )
+            if error_code:
+                grpc_status = testbench.common.http_to_grpc_status(error_code)
+                context.abort(
+                    grpc_status,
+                    "Retry Test: Caused a %s on half-close" % str(grpc_status),
                 )
 
         # Update metadata checksums fields on the upload instance.

--- a/testbench/common.py
+++ b/testbench/common.py
@@ -39,6 +39,10 @@ from google.storage.v2 import storage_pb2
 
 re_remove_index = re.compile(r"\[\d+\]+|^[0-9]+")
 retry_return_error_code = re.compile(r"return-([0-9]+)$")
+retry_return_error_code_on_finish_write = re.compile(
+    r"return-([0-9]+)-on-finish-write$"
+)
+retry_return_error_code_on_half_close = re.compile(r"return-([0-9]+)-on-half-close$")
 retry_return_error_connection = re.compile(r"return-([a-z\-]+)$")
 retry_return_error_after_bytes = re.compile(r"return-([0-9]+)-after-([0-9]+)K$")
 retry_return_short_response = re.compile(
@@ -51,6 +55,9 @@ retry_stall_after_bytes = re.compile(r"stall-for-([0-9]+)s-after-([0-9]+)K$")
 retry_return_redirection_token = re.compile(r"redirect-send-token-([a-z\-]+)$")
 retry_return_handle_and_redirection_token = re.compile(
     r"redirect-send-handle-and-token-([a-z\-]+)$"
+)
+retry_return_handle_and_redirection_token_on_finish_write = re.compile(
+    r"redirect-send-handle-and-token-([a-z\-]+)-on-finish-write$"
 )
 retry_expect_redirection_token = re.compile(r"redirect-expect-token-([a-z\-]+)$")
 retry_return_error_if_dp_enforced = re.compile(r"return-([0-9]+)-if-dp-enforced$")
@@ -1126,6 +1133,37 @@ def get_return_write_handle_and_redirect_token(db, context):
     return _get_grpc_instruction_match(
         db, context, "storage.objects.insert", retry_return_handle_and_redirection_token
     )
+
+
+def get_return_write_handle_and_redirect_token_on_finish_write(db, context):
+    return _get_grpc_instruction_match(
+        db,
+        context,
+        "storage.objects.insert",
+        retry_return_handle_and_redirection_token_on_finish_write,
+    )
+
+
+def get_return_error_code_on_finish_write(db, context):
+    return _get_grpc_instruction_match(
+        db, context, "storage.objects.insert", retry_return_error_code_on_finish_write
+    )
+
+
+def get_return_error_code_on_half_close(db, context):
+    return _get_grpc_instruction_match(
+        db, context, "storage.objects.insert", retry_return_error_code_on_half_close
+    )
+
+
+def http_to_grpc_status(error_code_str: str) -> StatusCode:
+    mapping = {
+        "503": StatusCode.UNAVAILABLE,
+        "500": StatusCode.INTERNAL,
+        "504": StatusCode.DEADLINE_EXCEEDED,
+        "429": StatusCode.RESOURCE_EXHAUSTED,
+    }
+    return mapping.get(error_code_str, StatusCode.UNKNOWN)
 
 
 def get_return_read_handle_and_redirect_token(db, context):

--- a/testbench/database.py
+++ b/testbench/database.py
@@ -659,6 +659,8 @@ class Database:
     def __validate_injected_failure_description(self, failure):
         for expr in [
             testbench.common.retry_return_error_code,
+            testbench.common.retry_return_error_code_on_finish_write,
+            testbench.common.retry_return_error_code_on_half_close,
             testbench.common.retry_return_error_connection,
             testbench.common.retry_return_error_after_bytes,
             testbench.common.retry_return_short_response,
@@ -666,6 +668,7 @@ class Database:
             testbench.common.retry_stall_after_bytes,
             testbench.common.retry_return_redirection_token,
             testbench.common.retry_return_handle_and_redirection_token,
+            testbench.common.retry_return_handle_and_redirection_token_on_finish_write,
             testbench.common.retry_expect_redirection_token,
             testbench.common.retry_return_unreachable_buckets,
             testbench.common.retry_return_error_if_dp_enforced,


### PR DESCRIPTION
Fixes b/532527637

Context:
The testbench currently lacks the ability to inject faults exactly when a stream is finalized (finish_write=True) or gracefully half-closed. This feature is required to verify retry logic in the Python SDK's AsyncAppendableObjectWriter during .finalize() and .close() operations (b/532527637).

Changes: 
Added three new instructions to the storage.objects.insert fault injection suite:
return-[error_code]-on-finish-write
return-[error_code]-on-half-close
redirect-send-handle-and-token-[token]-on-finish-write

Implementation:
common.py: Added regex parsers for the new instructions and an http_to_grpc_status converter.
database.py: Registered the new instructions in the validation suite to allow test setup.
upload.py: Added traps inside the BidiWriteObject upload loop. The stream now checks for these instructions and executes context.abort() with the requested error exactly when request.finish_write is received or the stream is half-closed.
